### PR TITLE
Add 3DEN categories and menu strip entry to main component

### DIFF
--- a/addons/main/CfgEden.hpp
+++ b/addons/main/CfgEden.hpp
@@ -1,0 +1,11 @@
+class Cfg3DEN {
+    class Object {
+        class AttributeCategories {
+            class PREFIX {
+                displayName = CSTRING(Attributes);
+                collapsed = 1;
+                class Attributes {};
+            };
+        };
+    };
+};

--- a/addons/main/CfgModuleCategories.hpp
+++ b/addons/main/CfgModuleCategories.hpp
@@ -1,0 +1,12 @@
+class CfgFactionClasses {
+    class NO_CATEGORY;
+    class PREFIX: NO_CATEGORY {
+        displayName = CSTRING(Category);
+    };
+};
+
+class CfgVehicleClasses {
+    class PREFIX##_Vehicles {
+        displayName = CSTRING(Category);
+    };
+};

--- a/addons/main/DisplayEden.hpp
+++ b/addons/main/DisplayEden.hpp
@@ -1,0 +1,13 @@
+class CtrlMenuStrip;
+class Display3DEN {
+    class Controls {
+        class MenuStrip: CtrlMenuStrip {
+            class Items {
+                items[] += {QUOTE(PREFIX)};
+                class PREFIX {
+                    text = CSTRING(Toolbar);
+                };
+            };
+        };
+    };
+};

--- a/addons/main/README.md
+++ b/addons/main/README.md
@@ -1,0 +1,7 @@
+## Main
+
+Base for other components. Provides CBA Macros framework, editor categories and similar.
+
+### Authors
+
+- [veteran29](http://github.com/veteran29)

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -13,3 +13,7 @@ class CfgPatches {
         VERSION_CONFIG;
     };
 };
+
+#include "CfgEden.hpp"
+#include "CfgModuleCategories.hpp"
+#include "DisplayEden.hpp"

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="AFM">
+    <Package name="Main">
+        <Key ID="STR_AFM_Main_Attributes">
+            <Original>ArmaForces Attributes</Original>
+            <Polish>Atrybuty ArmaForces</Polish>
+        </Key>
+        <Key ID="STR_AFM_Main_Category">
+            <Original>ArmaForces</Original>
+        </Key>
+        <Key ID="STR_AFM_Main_Toolbar">
+            <Original>ArmaForces</Original>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
- Add 3DEN categories and menu strip entry to main component, for usage in other components
- readme to `main` component, could we have it in all components from now on?