### PR TITLE
Add killtracker component

### DIFF
--- a/addons/killtracker/$PBOPREFIX$
+++ b/addons/killtracker/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\afm\addons\killtracker

--- a/addons/killtracker/CfgEventHandlers.hpp
+++ b/addons/killtracker/CfgEventHandlers.hpp
@@ -1,0 +1,16 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayDebriefing {
+        ADDON = QUOTE(call FUNC(dumpStats));
+    };
+};

--- a/addons/killtracker/README.md
+++ b/addons/killtracker/README.md
@@ -1,0 +1,7 @@
+## Killtracker
+
+Dumps ACEX Killtracker stats to RPT upon game end.
+
+### Authors
+
+- [veteran29](http://github.com/veteran29)

--- a/addons/killtracker/XEH_PREP.hpp
+++ b/addons/killtracker/XEH_PREP.hpp
@@ -1,0 +1,1 @@
+PREP(dumpStats);

--- a/addons/killtracker/XEH_preInit.sqf
+++ b/addons/killtracker/XEH_preInit.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+ADDON = false;
+#include "XEH_PREP.hpp"
+ADDON = true;

--- a/addons/killtracker/XEH_preStart.sqf
+++ b/addons/killtracker/XEH_preStart.sqf
@@ -1,0 +1,2 @@
+#include "script_component.hpp"
+#include "XEH_PREP.hpp"

--- a/addons/killtracker/config.cpp
+++ b/addons/killtracker/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "afm_main"
+        };
+        author = "ArmaForces";
+        authors[] = {"veteran29"};
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/killtracker/functions/fnc_dumpStats.sqf
+++ b/addons/killtracker/functions/fnc_dumpStats.sqf
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+/*
+ * Author: veteran29
+ * Dumps ACEX Killtracker stats to RPT
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Public: No
+ */
+
+diag_log text "------ [START_KILLTRACKER_STATS] ------";
+diag_log nil;
+
+{
+    diag_log text _x;
+} forEach acex_killTracker_eventsArray;
+
+diag_log nil;
+diag_log text "------ [END_KILLTRACKER_STATS] ------";
+
+nil
+

--- a/addons/killtracker/functions/fnc_dumpStats.sqf
+++ b/addons/killtracker/functions/fnc_dumpStats.sqf
@@ -17,13 +17,11 @@ if (isNil "acex_killTracker_eventsArray") exitWith {
 };
 
 diag_log text "------ [START_KILLTRACKER_STATS] ------";
-diag_log nil;
 
 {
     diag_log text _x;
 } forEach acex_killTracker_eventsArray;
 
-diag_log nil;
 diag_log text "------ [END_KILLTRACKER_STATS] ------";
 
 nil

--- a/addons/killtracker/functions/fnc_dumpStats.sqf
+++ b/addons/killtracker/functions/fnc_dumpStats.sqf
@@ -12,6 +12,10 @@
  * Public: No
  */
 
+if (isNil "acex_killTracker_eventsArray") exitWith {
+    WARNING("ACEX Killtracker not detected, can't show stats");
+};
+
 diag_log text "------ [START_KILLTRACKER_STATS] ------";
 diag_log nil;
 

--- a/addons/killtracker/functions/script_component.hpp
+++ b/addons/killtracker/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "..\script_component.hpp"

--- a/addons/killtracker/script_component.hpp
+++ b/addons/killtracker/script_component.hpp
@@ -1,0 +1,15 @@
+#define COMPONENT killtracker
+#include "\z\afm\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+
+#ifdef DEBUG_ENABLED_KILLTRACKER
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_KILLTRACKER
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_KILLTRACKER
+#endif
+
+#include "\z\afm\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- title
- dump ACEX stats to RPT on game end
- soft dependency
- relies on killtracker being enabled, thus CfgDebriefing entry is required


Example output:
```
 1:12:02 ------ [START_KILLTRACKER_STATS] ------
 1:12:02 KILLED: *AI* - Competitor  - [FatalInjury:Death]
 1:12:02 KILLED: *AI* - Competitor  - [FatalInjury:Death]
 1:12:02 KILLED: *AI* - Competitor  - [FatalInjury:Death]
 1:12:02 KILLED: *AI* - Competitor  - [FatalInjury:Death]
 1:12:02 ------ [END_KILLTRACKER_STATS] ------
```
