### PR TITLE
Add spectator

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -1,4 +1,4 @@
+PREP(isUnconscious);
 PREP(modal);
-
 PREP(onModalOpen);
 PREP(onModalClose);

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -4,5 +4,6 @@ ADDON = false;
 
 GVAR(aceSafemode) = IS_MOD_LOADED(ace_safemode);
 GVAR(aceFastroping) = IS_MOD_LOADED(ace_fastroping);
+GVAR(aceMedical) = IS_MOD_LOADED(ace_medical_engine);
 
 ADDON = true;

--- a/addons/common/functions/fnc_isUnconscious.sqf
+++ b/addons/common/functions/fnc_isUnconscious.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function checks if given unit is unconscious/incapacitated
+ *
+ * Arguments:
+ * 0: Unit to check <OBJECT>
+ *
+ * Return Value:
+ * 0: Is unconscious <BOOL>
+ *
+ * Example:
+ * [player] call afm_common_fnc_isUnconscious
+ *
+ * Public: No
+ */
+
+params ["_unit"];
+
+if (EGVAR(common,aceMedical)) then {
+    _unit getVariable ["ACE_isUnconscious", false];
+} else {
+    lifeState _unit isEqualTo "INCAPACITATED"
+};

--- a/addons/common/functions/fnc_isUnconscious.sqf
+++ b/addons/common/functions/fnc_isUnconscious.sqf
@@ -18,7 +18,7 @@
 params ["_unit"];
 
 if (EGVAR(common,aceMedical)) then {
-    _unit getVariable ["ACE_isUnconscious", false];
+    _unit getVariable ["ACE_isUnconscious", false]
 } else {
     lifeState _unit isEqualTo "INCAPACITATED"
 };

--- a/addons/spectator/$PBOPREFIX$
+++ b/addons/spectator/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\afm\addons\spectator

--- a/addons/spectator/CfgEventHandlers.hpp
+++ b/addons/spectator/CfgEventHandlers.hpp
@@ -1,0 +1,15 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/spectator/XEH_PREP.hpp
+++ b/addons/spectator/XEH_PREP.hpp
@@ -1,6 +1,7 @@
 PREP(canSpectate);
 PREP(disable);
 PREP(enable);
+PREP(reloadLocal);
 PREP(restart);
 PREP(start);
 PREP(stop);

--- a/addons/spectator/XEH_PREP.hpp
+++ b/addons/spectator/XEH_PREP.hpp
@@ -1,3 +1,5 @@
 PREP(canSpectate);
+PREP(disable);
+PREP(enable);
 PREP(start);
 PREP(stop);

--- a/addons/spectator/XEH_PREP.hpp
+++ b/addons/spectator/XEH_PREP.hpp
@@ -1,0 +1,1 @@
+PREP(start);

--- a/addons/spectator/XEH_PREP.hpp
+++ b/addons/spectator/XEH_PREP.hpp
@@ -1,2 +1,3 @@
+PREP(canSpectate);
 PREP(start);
 PREP(stop);

--- a/addons/spectator/XEH_PREP.hpp
+++ b/addons/spectator/XEH_PREP.hpp
@@ -3,3 +3,4 @@ PREP(disable);
 PREP(enable);
 PREP(start);
 PREP(stop);
+PREP(toggle);

--- a/addons/spectator/XEH_PREP.hpp
+++ b/addons/spectator/XEH_PREP.hpp
@@ -1,6 +1,7 @@
 PREP(canSpectate);
 PREP(disable);
 PREP(enable);
+PREP(restart);
 PREP(start);
 PREP(stop);
 PREP(toggle);

--- a/addons/spectator/XEH_PREP.hpp
+++ b/addons/spectator/XEH_PREP.hpp
@@ -1,1 +1,2 @@
 PREP(start);
+PREP(stop);

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -1,0 +1,1 @@
+#include "script_component.hpp"

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -23,7 +23,7 @@ if (hasInterface) then {
     if (EGVAR(common,aceMedical)) then {
         ["ace_unconscious", {
             params ["_unit", "_active"];
-            if (!(local _unit)) exitWith {};
+            if (!(_unit isEqualTo player)) exitWith {};
             if (_active) then {
                 [{!([player] call FUNC(canSpectate))}, {
                     // Do nothing as player can no longer be spectator, probably he's not unconscious anymore

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -4,4 +4,8 @@ if (hasInterface) then {
     [QGVAR(start), {
         _this call FUNC(start);
     }] call CBA_fnc_addEventHandler;
+
+    [QGVAR(stop), {
+        _this call FUNC(stop);
+    }] call CBA_fnc_addEventHandler;
 };

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -8,4 +8,14 @@ if (hasInterface) then {
     [QGVAR(stop), {
         _this call FUNC(stop);
     }] call CBA_fnc_addEventHandler;
+
+    player addEventHandler ["Killed", {
+        if (!GVAR(enabled)) exitWith {};
+        [QGVAR(start)] call CBA_fnc_localEvent;
+    }];
+
+    player addEventHandler ["Respawn", {
+        if (!GVAR(enabled)) exitWith {};
+        [QGVAR(stop)] call CBA_fnc_localEvent;
+    }];
 };

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -9,6 +9,7 @@ if (hasInterface) then {
         _this call FUNC(stop);
     }] call CBA_fnc_addEventHandler;
 
+    // State change event handlers to detect dying, respawning  and unconscious state change
     player addEventHandler ["Killed", {
         if (!GVAR(enabled)) exitWith {};
         [QGVAR(start)] call CBA_fnc_localEvent;
@@ -18,4 +19,18 @@ if (hasInterface) then {
         if (!GVAR(enabled)) exitWith {};
         [QGVAR(stop)] call CBA_fnc_localEvent;
     }];
+
+    if (EGVAR(common,aceMedical)) then {
+        ["ace_unconscious", {
+            params ["_unit", "_active"];
+            if (!(local _unit)) exitWith {};
+            if (_active) then {
+                [QGVAR(start)] call CBA_fnc_localEvent;
+            } else {
+                [QGVAR(stop)] call CBA_fnc_localEvent;
+            };
+        }] call CBA_fnc_addEventHandler;
+    } else {
+        // TODO: Handle vanilla unconscious state change
+    };
 };

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -29,6 +29,8 @@ if (hasInterface) then {
                     // Do nothing as player can no longer be spectator, probably he's not unconscious anymore
                 }, [], GVAR(unconsciousDelay), {
                     [QGVAR(start)] call CBA_fnc_localEvent;
+                    // Disable ACE's disable user input
+                    ["unconscious", false] call ACEFUNC(common,setDisableUserInputStatus);
                 }] call CBA_fnc_waitUntilAndExecute;
             } else {
                 [QGVAR(stop)] call CBA_fnc_localEvent;

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -12,11 +12,13 @@ if (hasInterface) then {
     // State change event handlers to detect dying, respawning  and unconscious state change
     player addEventHandler ["Killed", {
         if (!GVAR(enabled)) exitWith {};
+        WARNING("Player killed!");
         [QGVAR(start)] call CBA_fnc_localEvent;
     }];
 
     player addEventHandler ["Respawn", {
         if (!GVAR(enabled)) exitWith {};
+        WARNING("Player respawned!");
         [QGVAR(stop)] call CBA_fnc_localEvent;
     }];
 
@@ -28,11 +30,14 @@ if (hasInterface) then {
                 [{!([player] call FUNC(canSpectate))}, {
                     // Do nothing as player can no longer be spectator, probably he's not unconscious anymore
                 }, [], GVAR(unconsciousDelay), {
+                    WARNING("Player unconscious!");
                     [QGVAR(start)] call CBA_fnc_localEvent;
                     // Disable ACE's disable user input
                     ["unconscious", false] call ACEFUNC(common,setDisableUserInputStatus);
                 }] call CBA_fnc_waitUntilAndExecute;
             } else {
+                if (!alive _unit) exitWith {};
+                WARNING("Player no longer unconscious!");
                 [QGVAR(stop)] call CBA_fnc_localEvent;
             };
         }] call CBA_fnc_addEventHandler;

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -25,7 +25,11 @@ if (hasInterface) then {
             params ["_unit", "_active"];
             if (!(local _unit)) exitWith {};
             if (_active) then {
-                [QGVAR(start)] call CBA_fnc_localEvent;
+                [{!([player] call FUNC(canSpectate))}, {
+                    // Do nothing as player can no longer be spectator, probably he's not unconscious anymore
+                }, [], GVAR(unconsciousDelay), {
+                    [QGVAR(start)] call CBA_fnc_localEvent;
+                }] call CBA_fnc_waitUntilAndExecute;
             } else {
                 [QGVAR(stop)] call CBA_fnc_localEvent;
             };

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -40,7 +40,10 @@ if (hasInterface) then {
                     ["unconscious", false] call ACEFUNC(common,setDisableUserInputStatus);
                 }] call CBA_fnc_waitUntilAndExecute;
             } else {
-                if (!alive _unit) exitWith {};
+                if (!alive _unit) exitWith {
+                    // Player died, we need to reload his spectator for new params
+                    [QGVAR(reloadLocal)] call CBA_fnc_localEvent;
+                };
                 WARNING("Player no longer unconscious!");
                 [QGVAR(stop)] call CBA_fnc_localEvent;
             };

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -1,1 +1,7 @@
 #include "script_component.hpp"
+
+if (hasInterface) then {
+    [QGVAR(start), {
+        _this call FUNC(start);
+    }] call CBA_fnc_addEventHandler;
+};

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -9,6 +9,10 @@ if (hasInterface) then {
         _this call FUNC(stop);
     }] call CBA_fnc_addEventHandler;
 
+    [QGVAR(reloadLocal), {
+        _this call FUNC(reloadLocal);
+    }] call CBA_fnc_addEventHandler;
+
     // State change event handlers to detect dying, respawning  and unconscious state change
     player addEventHandler ["Killed", {
         if (!GVAR(enabled)) exitWith {};

--- a/addons/spectator/XEH_preInit.sqf
+++ b/addons/spectator/XEH_preInit.sqf
@@ -1,0 +1,4 @@
+#include "script_component.hpp"
+ADDON = false;
+#include "XEH_PREP.hpp"
+ADDON = true;

--- a/addons/spectator/XEH_preInit.sqf
+++ b/addons/spectator/XEH_preInit.sqf
@@ -1,4 +1,7 @@
 #include "script_component.hpp"
 ADDON = false;
 #include "XEH_PREP.hpp"
+
+#include "initSettings.sqf"
+
 ADDON = true;

--- a/addons/spectator/XEH_preStart.sqf
+++ b/addons/spectator/XEH_preStart.sqf
@@ -1,0 +1,2 @@
+#include "script_component.hpp"
+#include "XEH_PREP.hpp"

--- a/addons/spectator/config.cpp
+++ b/addons/spectator/config.cpp
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {};
+        author = "ArmaForces";
+        VERSION_CONFIG;
+    };
+};
+
+
+#include "CfgEventHandlers.hpp"

--- a/addons/spectator/functions/fnc_canSpectate.sqf
+++ b/addons/spectator/functions/fnc_canSpectate.sqf
@@ -17,6 +17,6 @@
 
 params [["_player", player]];
 
-!(alive player)
+!(alive _player)
 || {GVAR(allowUnconscious)
 && {[_player] call EFUNC(common,isUnconscious)}}

--- a/addons/spectator/functions/fnc_canSpectate.sqf
+++ b/addons/spectator/functions/fnc_canSpectate.sqf
@@ -18,10 +18,10 @@
 params [["_player", player]];
 
 // TODO: Check if is conscious (ACE or vanilla)
-private _conscious = if (EGVAR(common,aceMedical)) then {
+private _unconscious = if (EGVAR(common,aceMedical)) then {
     _player getVariable ["ACE_isUnconscious", false];
 } else {
-    !(lifeState _player isEqualTo "INCAPACITATED")
+    lifeState _player isEqualTo "INCAPACITATED"
 };
 
-!(alive player) || {!_conscious}
+!(alive player) || {_unconscious}

--- a/addons/spectator/functions/fnc_canSpectate.sqf
+++ b/addons/spectator/functions/fnc_canSpectate.sqf
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function checks if given player should see spectator camera
+ *
+ * Arguments:
+ * 0: Player unit <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player] call afm_spectator_fnc_canSpectate
+ *
+ * Public: No
+ */
+
+params [["_player", player]];
+
+// TODO: Check if is conscious (ACE or vanilla)
+private _conscious = false;
+
+!(alive player) || {!_conscious}

--- a/addons/spectator/functions/fnc_canSpectate.sqf
+++ b/addons/spectator/functions/fnc_canSpectate.sqf
@@ -17,11 +17,14 @@
 
 params [["_player", player]];
 
-// TODO: Check if is conscious (ACE or vanilla)
-private _unconscious = if (EGVAR(common,aceMedical)) then {
-    _player getVariable ["ACE_isUnconscious", false];
+private _unconscious = if (GVAR(allowUnconscious)) then {
+    if (EGVAR(common,aceMedical)) then {
+        _player getVariable ["ACE_isUnconscious", false];
+    } else {
+        lifeState _player isEqualTo "INCAPACITATED"
+    };
 } else {
-    lifeState _player isEqualTo "INCAPACITATED"
+    false
 };
 
 !(alive player) || {_unconscious}

--- a/addons/spectator/functions/fnc_canSpectate.sqf
+++ b/addons/spectator/functions/fnc_canSpectate.sqf
@@ -18,6 +18,10 @@
 params [["_player", player]];
 
 // TODO: Check if is conscious (ACE or vanilla)
-private _conscious = false;
+private _conscious = if (EGVAR(common,aceMedical)) then {
+    _player getVariable ["ACE_isUnconscious", false];
+} else {
+    !(lifeState _player isEqualTo "INCAPACITATED")
+};
 
 !(alive player) || {!_conscious}

--- a/addons/spectator/functions/fnc_canSpectate.sqf
+++ b/addons/spectator/functions/fnc_canSpectate.sqf
@@ -17,14 +17,6 @@
 
 params [["_player", player]];
 
-private _unconscious = if (GVAR(allowUnconscious)) then {
-    if (EGVAR(common,aceMedical)) then {
-        _player getVariable ["ACE_isUnconscious", false];
-    } else {
-        lifeState _player isEqualTo "INCAPACITATED"
-    };
-} else {
-    false
-};
-
-!(alive player) || {_unconscious}
+!(alive player)
+|| {GVAR(allowUnconscious)
+&& {[_player] call EFUNC(common,isUnconscious)}}

--- a/addons/spectator/functions/fnc_disable.sqf
+++ b/addons/spectator/functions/fnc_disable.sqf
@@ -7,7 +7,7 @@
  * 0: Enable spectator <BOOL>
  *
  * Return Value:
- * None
+ * 0: New spectator state <BOOL>
  *
  * Example:
  * [0] call afm_spectator_fnc_disable
@@ -18,3 +18,5 @@
 params ["_enabled"];
 
 [QGVAR(stop)] call CBA_fnc_globalEvent;
+
+false

--- a/addons/spectator/functions/fnc_disable.sqf
+++ b/addons/spectator/functions/fnc_disable.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 /*
  * Author: 3Mydlo3
- * Function disables spectator functionality
+ * Function disables spectator functionality.
  *
  * Arguments:
  * 0: Enable spectator <BOOL>
@@ -16,9 +16,5 @@
  */
 
 params ["_enabled"];
-
-if (!isServer) exitWith {};
-
-if (_enabled) exitWith {_this call FUNC(enable)};
 
 [QGVAR(stop)] call CBA_fnc_globalEvent;

--- a/addons/spectator/functions/fnc_disable.sqf
+++ b/addons/spectator/functions/fnc_disable.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function disables spectator functionality
+ *
+ * Arguments:
+ * 0: Enable spectator <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [0] call afm_spectator_fnc_disable
+ *
+ * Public: No
+ */
+
+params ["_enabled"];
+
+if (!isServer) exitWith {};
+
+if (_enabled) exitWith {_this call FUNC(enable)};
+
+[QGVAR(stop)] call CBA_fnc_globalEvent;

--- a/addons/spectator/functions/fnc_disable.sqf
+++ b/addons/spectator/functions/fnc_disable.sqf
@@ -4,7 +4,7 @@
  * Function disables spectator functionality.
  *
  * Arguments:
- * 0: Enable spectator <BOOL>
+ * None
  *
  * Return Value:
  * 0: New spectator state <BOOL>
@@ -14,8 +14,6 @@
  *
  * Public: No
  */
-
-params ["_enabled"];
 
 [QGVAR(stop)] call CBA_fnc_globalEvent;
 

--- a/addons/spectator/functions/fnc_enable.sqf
+++ b/addons/spectator/functions/fnc_enable.sqf
@@ -4,7 +4,7 @@
  * Function enables spectator functionality.
  *
  * Arguments:
- * 0: Enable spectator <BOOL>
+ * None
  *
  * Return Value:
  * 0: New spectator state <BOOL>
@@ -14,8 +14,6 @@
  *
  * Public: No
  */
-
-params ["_enabled"];
 
 {
     [QGVAR(start), [_x], _x] call CBA_fnc_targetEvent;

--- a/addons/spectator/functions/fnc_enable.sqf
+++ b/addons/spectator/functions/fnc_enable.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 /*
  * Author: 3Mydlo3
- * Function enables spectator functionality
+ * Function enables spectator functionality.
  *
  * Arguments:
  * 0: Enable spectator <BOOL>
@@ -16,10 +16,6 @@
  */
 
 params ["_enabled"];
-
-if (!isServer) exitWith {};
-
-if (!(_enabled)) exitWith {_this call FUNC(disable)};
 
 {
     [QGVAR(start), [_x], _x] call CBA_fnc_targetEvent;

--- a/addons/spectator/functions/fnc_enable.sqf
+++ b/addons/spectator/functions/fnc_enable.sqf
@@ -7,7 +7,7 @@
  * 0: Enable spectator <BOOL>
  *
  * Return Value:
- * None
+ * 0: New spectator state <BOOL>
  *
  * Example:
  * [1] call afm_spectator_fnc_enable
@@ -20,3 +20,5 @@ params ["_enabled"];
 {
     [QGVAR(start), [_x], _x] call CBA_fnc_targetEvent;
 } forEach (allPlayers select {[_x] call FUNC(canSpectate)});
+
+true

--- a/addons/spectator/functions/fnc_enable.sqf
+++ b/addons/spectator/functions/fnc_enable.sqf
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function enables spectator functionality
+ *
+ * Arguments:
+ * 0: Enable spectator <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [1] call afm_spectator_fnc_enable
+ *
+ * Public: No
+ */
+
+params ["_enabled"];
+
+if (!isServer) exitWith {};
+
+if (!(_enabled)) exitWith {_this call FUNC(disable)};
+
+{
+    [QGVAR(start), [_x], _x] call CBA_fnc_targetEvent;
+} forEach (allPlayers select {[_x] call FUNC(canSpectate)});

--- a/addons/spectator/functions/fnc_reloadLocal.sqf
+++ b/addons/spectator/functions/fnc_reloadLocal.sqf
@@ -47,3 +47,5 @@ if ([player] call FUNC(canSpectate)) then {
 };
 
 GVAR(oldSpectatorCamera) = nil;
+
+nil

--- a/addons/spectator/functions/fnc_reloadLocal.sqf
+++ b/addons/spectator/functions/fnc_reloadLocal.sqf
@@ -1,0 +1,49 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function reloads local spectator
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * call afm_spectator_fnc_reloadLocal
+ *
+ * Public: No
+ */
+
+WARNING("Reloading spectator!");
+
+if (["IsInitialized"] call BIS_fnc_EGSpectator) then {
+    private _oldSpectatorCamera = BIS_EGSpectatorCamera_Camera;
+    GVAR(oldSpectatorCamera) = [
+        getPos _oldSpectatorCamera,
+        vectorDir _oldSpectatorCamera,
+        vectorUp _oldSpectatorCamera,
+        attachedTo (["GetDummyTarget"] call BIS_fnc_EGSpectatorCamera)
+    ];
+    [QGVAR(stop)] call CBA_fnc_localEvent;
+};
+
+if ([player] call FUNC(canSpectate)) then {
+    // Start spectator
+    [QGVAR(start)] call CBA_fnc_localEvent;
+
+    // Move camera to last position if spectator was enabled before
+    if (!isNil QGVAR(oldSpectatorCamera)) then {
+        WARNING("Moving camera to old position.");
+        private _newSpectatorCamera = BIS_EGSpectatorCamera_camera;
+        _newSpectatorCamera setPos (GVAR(oldSpectatorCamera) select 0);
+        _newSpectatorCamera setVectorDir (GVAR(oldSpectatorCamera) select 1);
+        _newSpectatorCamera setVectorUp (GVAR(oldSpectatorCamera) select 2);
+        private _targetObject = GVAR(oldSpectatorCamera) select 3;
+        if (!(_targetObject isEqualTo objNull)) then {
+            [_targetObject] call BIS_fnc_EGSpectatorCameraSetTarget;
+        };
+    };
+};
+
+GVAR(oldSpectatorCamera) = nil;

--- a/addons/spectator/functions/fnc_restart.sqf
+++ b/addons/spectator/functions/fnc_restart.sqf
@@ -17,5 +17,5 @@
 
 if (!isServer) exitWith {};
 
-call FUNC(disable);
-call FUNC(enable);
+WARNING("Restarting spectator!");
+[QGVAR(reloadLocal)] call CBA_fnc_globalEvent;

--- a/addons/spectator/functions/fnc_restart.sqf
+++ b/addons/spectator/functions/fnc_restart.sqf
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function restarts all spectators.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * call afm_spectator_fnc_restart
+ *
+ * Public: No
+ */
+
+if (!isServer) exitWith {};
+
+call FUNC(disable);
+call FUNC(enable);

--- a/addons/spectator/functions/fnc_restart.sqf
+++ b/addons/spectator/functions/fnc_restart.sqf
@@ -19,3 +19,5 @@ if (!isServer) exitWith {};
 
 WARNING("Restarting spectator!");
 [QGVAR(reloadLocal)] call CBA_fnc_globalEvent;
+
+nil

--- a/addons/spectator/functions/fnc_start.sqf
+++ b/addons/spectator/functions/fnc_start.sqf
@@ -48,3 +48,5 @@ if (_civilianSide) then {
 // Start spectator
 ["Initialize", [player, _whitelistedSides, _allowAI, _freeCamera, _TPPCamera, true, true, true, true, true]] call BIS_fnc_EGSpectator;
 WARNING("Starting spectator!");
+
+nil

--- a/addons/spectator/functions/fnc_start.sqf
+++ b/addons/spectator/functions/fnc_start.sqf
@@ -30,5 +30,9 @@ private _whitelistedSides = switch GVAR(sides) do {
     default {player call BIS_fnc_friendlySides};
 };
 
+if (GVAR(civilianSide)) then {
+    _whitelistedSides pushBack CIVILIAN;
+};
+
 // Start spectator
 ["Initialize", [player, _whitelistedSides, false, true, true, true, true, true, true, true]] call BIS_fnc_EGSpectator;

--- a/addons/spectator/functions/fnc_start.sqf
+++ b/addons/spectator/functions/fnc_start.sqf
@@ -19,4 +19,16 @@ params [["_player", player]];
 
 if (!(local _player)) exitWith {[QGVAR(start), _this, _player] call CBA_fnc_targetEvent};
 
-["Initialize", [player, [], false, true, true, true, true, true, true, true]] call BIS_fnc_EGSpectator;
+// Determine sides available for spectating
+private _whitelistedSides = switch GVAR(sides) do {
+    // Friendly sides spectator
+    case 0: {player call BIS_fnc_friendlySides};
+    // Player side spectator
+    case 1: {[playerSide]};
+    // All sides spectator
+    case 2: {[WEST, INDEPENDENT, EAST]};
+    default {player call BIS_fnc_friendlySides};
+};
+
+// Start spectator
+["Initialize", [player, _whitelistedSides, false, true, true, true, true, true, true, true]] call BIS_fnc_EGSpectator;

--- a/addons/spectator/functions/fnc_start.sqf
+++ b/addons/spectator/functions/fnc_start.sqf
@@ -19,6 +19,8 @@ params [["_player", player]];
 
 if (!(local _player)) exitWith {[QGVAR(start), _this, _player] call CBA_fnc_targetEvent};
 
+if (["IsInitialized"] call BIS_fnc_EGSpectator) exitWith {WARNING("Spectator already initialized!")};
+
 // Determine sides available for spectating
 private _whitelistedSides = switch GVAR(sides) do {
     // Friendly sides spectator
@@ -36,3 +38,4 @@ if (GVAR(civilianSide)) then {
 
 // Start spectator
 ["Initialize", [player, _whitelistedSides, GVAR(allowAI), GVAR(freeCamera), GVAR(TPPCamera), true, true, true, true, true]] call BIS_fnc_EGSpectator;
+WARNING("Starting spectator!");

--- a/addons/spectator/functions/fnc_start.sqf
+++ b/addons/spectator/functions/fnc_start.sqf
@@ -21,8 +21,17 @@ if (!(local _player)) exitWith {[QGVAR(start), _this, _player] call CBA_fnc_targ
 
 if (["IsInitialized"] call BIS_fnc_EGSpectator) exitWith {WARNING("Spectator already initialized!")};
 
+// Determine spectator parameters based on player consciousness
+private _unconscious = [player] call EFUNC(common,isUnconscious);
+
+private _sides = [GVAR(sides), GVAR(sidesUnconscious)] select _unconscious;
+private _civilianSide = [GVAR(civilianSide), GVAR(civilianSideUnconscious)] select _unconscious;
+private _allowAI = [GVAR(allowAI), GVAR(allowAIUnconscious)] select _unconscious;
+private _freeCamera = [GVAR(freeCamera), GVAR(freeCameraUnconscious)] select _unconscious;
+private _TPPCamera = [GVAR(TPPCamera), GVAR(TPPCameraUnconscious)] select _unconscious;
+
 // Determine sides available for spectating
-private _whitelistedSides = switch GVAR(sides) do {
+private _whitelistedSides = switch _sides do {
     // Friendly sides spectator
     case 0: {playerSide call BIS_fnc_friendlySides};
     // Player side spectator
@@ -32,10 +41,10 @@ private _whitelistedSides = switch GVAR(sides) do {
     default {playerSide call BIS_fnc_friendlySides};
 };
 
-if (GVAR(civilianSide)) then {
+if (_civilianSide) then {
     _whitelistedSides pushBack CIVILIAN;
 };
 
 // Start spectator
-["Initialize", [player, _whitelistedSides, GVAR(allowAI), GVAR(freeCamera), GVAR(TPPCamera), true, true, true, true, true]] call BIS_fnc_EGSpectator;
+["Initialize", [player, _whitelistedSides, _allowAI, _freeCamera, _TPPCamera, true, true, true, true, true]] call BIS_fnc_EGSpectator;
 WARNING("Starting spectator!");

--- a/addons/spectator/functions/fnc_start.sqf
+++ b/addons/spectator/functions/fnc_start.sqf
@@ -35,4 +35,4 @@ if (GVAR(civilianSide)) then {
 };
 
 // Start spectator
-["Initialize", [player, _whitelistedSides, GVAR(allowAI), true, true, true, true, true, true, true]] call BIS_fnc_EGSpectator;
+["Initialize", [player, _whitelistedSides, GVAR(allowAI), GVAR(freeCamera), true, true, true, true, true, true]] call BIS_fnc_EGSpectator;

--- a/addons/spectator/functions/fnc_start.sqf
+++ b/addons/spectator/functions/fnc_start.sqf
@@ -35,4 +35,4 @@ if (GVAR(civilianSide)) then {
 };
 
 // Start spectator
-["Initialize", [player, _whitelistedSides, false, true, true, true, true, true, true, true]] call BIS_fnc_EGSpectator;
+["Initialize", [player, _whitelistedSides, GVAR(allowAI), true, true, true, true, true, true, true]] call BIS_fnc_EGSpectator;

--- a/addons/spectator/functions/fnc_start.sqf
+++ b/addons/spectator/functions/fnc_start.sqf
@@ -22,12 +22,12 @@ if (!(local _player)) exitWith {[QGVAR(start), _this, _player] call CBA_fnc_targ
 // Determine sides available for spectating
 private _whitelistedSides = switch GVAR(sides) do {
     // Friendly sides spectator
-    case 0: {player call BIS_fnc_friendlySides};
+    case 0: {playerSide call BIS_fnc_friendlySides};
     // Player side spectator
     case 1: {[playerSide]};
     // All sides spectator
     case 2: {[WEST, INDEPENDENT, EAST]};
-    default {player call BIS_fnc_friendlySides};
+    default {playerSide call BIS_fnc_friendlySides};
 };
 
 if (GVAR(civilianSide)) then {

--- a/addons/spectator/functions/fnc_start.sqf
+++ b/addons/spectator/functions/fnc_start.sqf
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function starts spectator for given player
+ *
+ * Arguments:
+ * 0: player unit <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player] call afm_spectator_fnc_start
+ *
+ * Public: No
+ */
+
+params ["_player"];
+
+if (!(local _player)) exitWith {[QGVAR(start), _this, _player] call CBA_fnc_targetEvent};
+
+["Initialize", [player, [], false, true, true, true, true, true, true, true]] call BIS_fnc_EGSpectator;

--- a/addons/spectator/functions/fnc_start.sqf
+++ b/addons/spectator/functions/fnc_start.sqf
@@ -35,4 +35,4 @@ if (GVAR(civilianSide)) then {
 };
 
 // Start spectator
-["Initialize", [player, _whitelistedSides, GVAR(allowAI), GVAR(freeCamera), true, true, true, true, true, true]] call BIS_fnc_EGSpectator;
+["Initialize", [player, _whitelistedSides, GVAR(allowAI), GVAR(freeCamera), GVAR(TPPCamera), true, true, true, true, true]] call BIS_fnc_EGSpectator;

--- a/addons/spectator/functions/fnc_start.sqf
+++ b/addons/spectator/functions/fnc_start.sqf
@@ -15,7 +15,7 @@
  * Public: No
  */
 
-params ["_player"];
+params [["_player", player]];
 
 if (!(local _player)) exitWith {[QGVAR(start), _this, _player] call CBA_fnc_targetEvent};
 

--- a/addons/spectator/functions/fnc_stop.sqf
+++ b/addons/spectator/functions/fnc_stop.sqf
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function terminates spectator for given player
+ *
+ * Arguments:
+ * 0: player unit <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player] call afm_spectator_fnc_stop
+ *
+ * Public: No
+ */
+
+params ["_player"];
+
+if (!(local _player)) exitWith {[QGVAR(start), _this, _player] call CBA_fnc_targetEvent};
+
+["Terminate"] call BIS_fnc_EGSpectator;

--- a/addons/spectator/functions/fnc_stop.sqf
+++ b/addons/spectator/functions/fnc_stop.sqf
@@ -20,3 +20,4 @@ params [["_player", player]];
 if (!(local _player)) exitWith {[QGVAR(start), _this, _player] call CBA_fnc_targetEvent};
 
 ["Terminate"] call BIS_fnc_EGSpectator;
+WARNING("Stopping spectator!");

--- a/addons/spectator/functions/fnc_stop.sqf
+++ b/addons/spectator/functions/fnc_stop.sqf
@@ -21,3 +21,5 @@ if (!(local _player)) exitWith {[QGVAR(start), _this, _player] call CBA_fnc_targ
 
 ["Terminate"] call BIS_fnc_EGSpectator;
 WARNING("Stopping spectator!");
+
+nil

--- a/addons/spectator/functions/fnc_stop.sqf
+++ b/addons/spectator/functions/fnc_stop.sqf
@@ -15,7 +15,7 @@
  * Public: No
  */
 
-params ["_player"];
+params [["_player", player]];
 
 if (!(local _player)) exitWith {[QGVAR(start), _this, _player] call CBA_fnc_targetEvent};
 

--- a/addons/spectator/functions/fnc_toggle.sqf
+++ b/addons/spectator/functions/fnc_toggle.sqf
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function toggles spectator enabled/disabled.
+ *
+ * Arguments:
+ * 0: Spectator enabled <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [[bob, ted], false] call afm_spectator_fnc_toggle
+ *
+ * Public: No
+ */
+
+params ["_enabled"];
+
+if (!isServer) exitWith {};
+
+if (_enabled) then {
+    _this call FUNC(enable)
+} else {
+    _this call FUNC(disable)
+};

--- a/addons/spectator/functions/fnc_toggle.sqf
+++ b/addons/spectator/functions/fnc_toggle.sqf
@@ -7,10 +7,10 @@
  * 0: Spectator enabled <BOOL>
  *
  * Return Value:
- * None
+ * 0: New spectator state <BOOL>
  *
  * Example:
- * [[bob, ted], false] call afm_spectator_fnc_toggle
+ * [true] call afm_spectator_fnc_toggle
  *
  * Public: No
  */

--- a/addons/spectator/functions/script_component.hpp
+++ b/addons/spectator/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\z\afm\addons\spectator\script_component.hpp"

--- a/addons/spectator/initSettings.sqf
+++ b/addons/spectator/initSettings.sqf
@@ -19,6 +19,15 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(unconsciousDelay),
+    "SLIDER",
+    [LSTRING(UnconsciousDelay), LSTRING(UnconsciousDelay_Description)],
+    LSTRING(DisplayName),
+    [1, 300, 30, 0],
+    1
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(sides),
     "LIST",
     [LSTRING(Sides), LSTRING(Sides_Description)],

--- a/addons/spectator/initSettings.sqf
+++ b/addons/spectator/initSettings.sqf
@@ -9,6 +9,16 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(allowUnconscious),
+    "CHECKBOX",
+    [LSTRING(AllowUnconscious), LSTRING(AllowUnconscious_Description)],
+    LSTRING(DisplayName),
+    false,
+    1,
+    {[_this] call FUNC(restart)}
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(sides),
     "LIST",
     [LSTRING(Sides), LSTRING(Sides_Description)],

--- a/addons/spectator/initSettings.sqf
+++ b/addons/spectator/initSettings.sqf
@@ -47,3 +47,13 @@
     1,
     {[_this] call FUNC(restart)}
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(TPPCamera),
+    "CHECKBOX",
+    [LSTRING(TPPCamera), LSTRING(TPPCamera_Description)],
+    LSTRING(DisplayName),
+    false,
+    1,
+    {[_this] call FUNC(restart)}
+] call CBA_fnc_addSetting;

--- a/addons/spectator/initSettings.sqf
+++ b/addons/spectator/initSettings.sqf
@@ -12,7 +12,7 @@
     QGVAR(allowUnconscious),
     "CHECKBOX",
     [LSTRING(AllowUnconscious), LSTRING(AllowUnconscious_Description)],
-    LSTRING(DisplayName),
+    [LSTRING(DisplayName), LSTRING(Unconscious)],
     false,
     1,
     {[_this] call FUNC(restart)}
@@ -22,7 +22,7 @@
     QGVAR(unconsciousDelay),
     "SLIDER",
     [LSTRING(UnconsciousDelay), LSTRING(UnconsciousDelay_Description)],
-    LSTRING(DisplayName),
+    [LSTRING(DisplayName), LSTRING(Unconscious)],
     [1, 300, 30, 0],
     1
 ] call CBA_fnc_addSetting;

--- a/addons/spectator/initSettings.sqf
+++ b/addons/spectator/initSettings.sqf
@@ -17,3 +17,13 @@
     1,
     {[_this] call FUNC(restart)}
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(civilianSide),
+    "CHECKBOX",
+    [LSTRING(CivilianSide), LSTRING(CivilianSide_Description)],
+    LSTRING(DisplayName),
+    false,
+    1,
+    {[_this] call FUNC(restart)}
+] call CBA_fnc_addSetting;

--- a/addons/spectator/initSettings.sqf
+++ b/addons/spectator/initSettings.sqf
@@ -37,3 +37,13 @@
     1,
     {[_this] call FUNC(restart)}
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(freeCamera),
+    "CHECKBOX",
+    [LSTRING(FreeCamera), LSTRING(FreeCamera_Description)],
+    LSTRING(DisplayName),
+    false,
+    1,
+    {[_this] call FUNC(restart)}
+] call CBA_fnc_addSetting;

--- a/addons/spectator/initSettings.sqf
+++ b/addons/spectator/initSettings.sqf
@@ -1,0 +1,9 @@
+[
+    QGVAR(enabled),
+    "CHECKBOX",
+    [LSTRING(Enabled), LSTRING(Enabled_Description)],
+    LSTRING(DisplayName),
+    false,
+    1,
+    {[_this] call FUNC(enable)}
+] call CBA_fnc_addSetting;

--- a/addons/spectator/initSettings.sqf
+++ b/addons/spectator/initSettings.sqf
@@ -27,3 +27,13 @@
     1,
     {[_this] call FUNC(restart)}
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(allowAI),
+    "CHECKBOX",
+    [LSTRING(AllowAI), LSTRING(AllowAI_Description)],
+    LSTRING(DisplayName),
+    false,
+    1,
+    {[_this] call FUNC(restart)}
+] call CBA_fnc_addSetting;

--- a/addons/spectator/initSettings.sqf
+++ b/addons/spectator/initSettings.sqf
@@ -5,5 +5,5 @@
     LSTRING(DisplayName),
     false,
     1,
-    {[_this] call FUNC(enable)}
+    {[_this] call FUNC(toggle)}
 ] call CBA_fnc_addSetting;

--- a/addons/spectator/initSettings.sqf
+++ b/addons/spectator/initSettings.sqf
@@ -7,3 +7,13 @@
     1,
     {[_this] call FUNC(toggle)}
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(sides),
+    "LIST",
+    [LSTRING(Sides), LSTRING(Sides_Description)],
+    LSTRING(DisplayName),
+    [[0, 1, 2], [LSTRING(Friendly), LSTRING(Own), "str_all_voices"], 0],
+    1,
+    {[_this] call FUNC(restart)}
+] call CBA_fnc_addSetting;

--- a/addons/spectator/initSettings.sqf
+++ b/addons/spectator/initSettings.sqf
@@ -38,10 +38,30 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(sidesUnconscious),
+    "LIST",
+    [LSTRING(Sides), LSTRING(Sides_Description)],
+    [LSTRING(DisplayName), LSTRING(Unconscious)],
+    [[0, 1, 2], [LSTRING(Friendly), LSTRING(Own), "str_all_voices"], 0],
+    1,
+    {[_this] call FUNC(restart)}
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(civilianSide),
     "CHECKBOX",
     [LSTRING(CivilianSide), LSTRING(CivilianSide_Description)],
     LSTRING(DisplayName),
+    false,
+    1,
+    {[_this] call FUNC(restart)}
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(civilianSideUnconscious),
+    "CHECKBOX",
+    [LSTRING(CivilianSide), LSTRING(CivilianSide_Description)],
+    [LSTRING(DisplayName), LSTRING(Unconscious)],
     false,
     1,
     {[_this] call FUNC(restart)}
@@ -58,6 +78,16 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(allowAIUnconscious),
+    "CHECKBOX",
+    [LSTRING(AllowAI), LSTRING(AllowAI_Description)],
+    [LSTRING(DisplayName), LSTRING(Unconscious)],
+    false,
+    1,
+    {[_this] call FUNC(restart)}
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(freeCamera),
     "CHECKBOX",
     [LSTRING(FreeCamera), LSTRING(FreeCamera_Description)],
@@ -68,10 +98,30 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(freeCameraUnconscious),
+    "CHECKBOX",
+    [LSTRING(FreeCamera), LSTRING(FreeCamera_Description)],
+    [LSTRING(DisplayName), LSTRING(Unconscious)],
+    false,
+    1,
+    {[_this] call FUNC(restart)}
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(TPPCamera),
     "CHECKBOX",
     [LSTRING(TPPCamera), LSTRING(TPPCamera_Description)],
     LSTRING(DisplayName),
+    false,
+    1,
+    {[_this] call FUNC(restart)}
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(TPPCameraUnconscious),
+    "CHECKBOX",
+    [LSTRING(TPPCamera), LSTRING(TPPCamera_Description)],
+    [LSTRING(DisplayName), LSTRING(Unconscious)],
     false,
     1,
     {[_this] call FUNC(restart)}

--- a/addons/spectator/script_component.hpp
+++ b/addons/spectator/script_component.hpp
@@ -1,0 +1,14 @@
+#define COMPONENT spectator
+#include "\z\afm\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+
+#ifdef DEBUG_ENABLED_SPECTATOR
+    #define DEBUG_MODE_FULL
+#endif
+    #ifdef DEBUG_SETTINGS_SPECTATOR
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_SPECTATOR
+#endif
+
+#include "\z\afm\addons\main\script_macros.hpp"

--- a/addons/spectator/stringtable.xml
+++ b/addons/spectator/stringtable.xml
@@ -13,6 +13,10 @@
             <English>Enables spectator for dead players</English>
             <Polish>Włącza obserwatora martwym graczom</Polish>
         </Key>
+        <Key ID="STR_AFM_Spectator_Unconscious">
+            <English>Unconscious</English>
+            <Polish>Nieprzytomni</Polish>
+        </Key>
         <Key ID="STR_AFM_Spectator_AllowUnconscious">
             <English>Allow unconscious</English>
             <Polish>Obserwator dla nieprzytomnych</Polish>

--- a/addons/spectator/stringtable.xml
+++ b/addons/spectator/stringtable.xml
@@ -53,5 +53,13 @@
             <English>Allows spectator to move his camera freely.</English>
             <Polish>Pozwala obserwatorowi dowolnie poruszać kamerą.</Polish>
         </Key>
+        <Key ID="STR_AFM_Spectator_TPPCamera">
+            <English>Allow TPP Camera</English>
+            <Polish>Pozwól na trzecioosobową kamerę</Polish>
+        </Key>
+        <Key ID="STR_AFM_Spectator_TPPCamera_Description">
+            <English>Allows spectator to use third person camera.</English>
+            <Polish>Pozwala obserwatorowi używać kamery trzecioosobowej.</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/spectator/stringtable.xml
+++ b/addons/spectator/stringtable.xml
@@ -21,6 +21,14 @@
             <English>Enables spectator also for unconscious players. Requires enabling spectator.</English>
             <Polish>Włącza obserwatora także nieprzytomnym graczom. Wymaga włączenia obserwatora.</Polish>
         </Key>
+        <Key ID="STR_AFM_Spectator_UnconsciousDelay">
+            <English>Unconscious spectator delay</English>
+            <Polish>Opóźnienie obserwatora dla nieprzytomnych</Polish>
+        </Key>
+        <Key ID="STR_AFM_Spectator_UnconsciousDelay_Description">
+            <English>How much time must pass before unconscious players get spectator.</English>
+            <Polish>Ile czasu musi upłynąć nim nieprzytomni gracze dostaną obserwatora.</Polish>
+        </Key>
         <Key ID="STR_AFM_Spectator_Sides">
             <English>Sides available for spectating</English>
             <Polish>Dostępne strony do obserwowania</Polish>

--- a/addons/spectator/stringtable.xml
+++ b/addons/spectator/stringtable.xml
@@ -13,5 +13,21 @@
             <English>Enables spectator for dead players</English>
             <Polish>Włącza obserwatora martwym graczom</Polish>
         </Key>
+        <Key ID="STR_AFM_Spectator_Sides">
+            <English>Sides available for spectating</English>
+            <Polish>Dostępne strony do obserwowania</Polish>
+        </Key>
+        <Key ID="STR_AFM_Spectator_Sides_Description">
+            <English>Spectator will be able to see and track units from given sides.</English>
+            <Polish>Obserwator będzie mógł widzieć i śledzić jednostki wybranych stron.</Polish>
+        </Key>
+        <Key ID="STR_AFM_Spectator_Friendly">
+            <English>Friendly</English>
+            <Polish>Sojusznicze</Polish>
+        </Key>
+        <Key ID="STR_AFM_Spectator_Own">
+            <English>Player side</English>
+            <Polish>Strona gracza</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/spectator/stringtable.xml
+++ b/addons/spectator/stringtable.xml
@@ -29,5 +29,13 @@
             <English>Player side</English>
             <Polish>Strona gracza</Polish>
         </Key>
+        <Key ID="STR_AFM_Spectator_CivilianSide">
+            <English>Allow civilian spectating</English>
+            <Polish>Pozwól obserwować cywili</Polish>
+        </Key>
+        <Key ID="STR_AFM_Spectator_CivilianSide_Description">
+            <English>Allows tracking units from civilian side.</English>
+            <Polish>Pozwala obserwować jednostki strony cywilnej.</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/spectator/stringtable.xml
+++ b/addons/spectator/stringtable.xml
@@ -45,5 +45,13 @@
             <English>Allows tracking AI units from whitelisted sides.</English>
             <Polish>Pozwala obserwować jednostki AI z dozwolonych stron.</Polish>
         </Key>
+        <Key ID="STR_AFM_Spectator_FreeCamera">
+            <English>Allow free camera</English>
+            <Polish>Pozwól na wolną kamerę</Polish>
+        </Key>
+        <Key ID="STR_AFM_Spectator_FreeCamera_Description">
+            <English>Allows spectator to move his camera freely.</English>
+            <Polish>Pozwala obserwatorowi dowolnie poruszać kamerą.</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/spectator/stringtable.xml
+++ b/addons/spectator/stringtable.xml
@@ -37,5 +37,13 @@
             <English>Allows tracking units from civilian side.</English>
             <Polish>Pozwala obserwować jednostki strony cywilnej.</Polish>
         </Key>
+        <Key ID="STR_AFM_Spectator_AllowAI">
+            <English>Allow AI spectating</English>
+            <Polish>Pozwól obserwować AI</Polish>
+        </Key>
+        <Key ID="STR_AFM_Spectator_AllowAI_Description">
+            <English>Allows tracking AI units from whitelisted sides.</English>
+            <Polish>Pozwala obserwować jednostki AI z dozwolonych stron.</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/spectator/stringtable.xml
+++ b/addons/spectator/stringtable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="AFM">
+    <Package name="Spectator">
+        <Key ID="STR_AFM_Spectator_DisplayName">
+            <English>ArmaForces - Spectator</English>
+            <Polish>ArmaForces - Obserwator</Polish>
+        </Key>
+        <Key ID="STR_AFM_Spectator_Enabled">
+            <English>Enable spectator</English>
+            <Polish>Włącz obserwatora</Polish>
+        </Key>
+        <Key ID="STR_AFM_Spectator_Enabled_Description">
+            <English>Enables spectator for dead players</English>
+            <Polish>Włącza obserwatora martwym graczom</Polish>
+        </Key>
+    </Package>
+</Project>

--- a/addons/spectator/stringtable.xml
+++ b/addons/spectator/stringtable.xml
@@ -13,6 +13,14 @@
             <English>Enables spectator for dead players</English>
             <Polish>Włącza obserwatora martwym graczom</Polish>
         </Key>
+        <Key ID="STR_AFM_Spectator_AllowUnconscious">
+            <English>Allow unconscious</English>
+            <Polish>Obserwator dla nieprzytomnych</Polish>
+        </Key>
+        <Key ID="STR_AFM_Spectator_AllowUnconscious_Description">
+            <English>Enables spectator also for unconscious players. Requires enabling spectator.</English>
+            <Polish>Włącza obserwatora także nieprzytomnym graczom. Wymaga włączenia obserwatora.</Polish>
+        </Key>
         <Key ID="STR_AFM_Spectator_Sides">
             <English>Sides available for spectating</English>
             <Polish>Dostępne strony do obserwowania</Polish>


### PR DESCRIPTION
**When merged this pull request will:**
- Add spectator module
  - Highly customizable (selectable sides, camera modes)
  - Allows spectating for ACE unconscious units (if allowed in settings)
  - Separate settings customization for unconscious spectator
  - Supports changing settings on the fly (restores old camera position, direction and target)