### PR TITLE
Add function to create player owned marker

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -2,3 +2,4 @@ PREP(isUnconscious);
 PREP(modal);
 PREP(onModalOpen);
 PREP(onModalClose);
+PREP(createPlayerMarker);

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -20,6 +20,7 @@ if (isServer) then {
 };
 
 if (hasInterface) then {
+    GVAR(playerMarkerIdx) = 0;
     GVAR(clientId) = "";
 };
 

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -7,4 +7,20 @@ GVAR(aceFastroping) = IS_MOD_LOADED(ace_fastroping);
 GVAR(aceFatigue) = IS_MOD_LOADED(ace_advanced_fatigue);
 GVAR(aceMedical) = IS_MOD_LOADED(ace_medical_engine);
 
+if (isServer) then {
+    GVAR(clientId) = "2";
+
+    // publish Direct Play clientId to clients
+    addMissionEventHandler ["PlayerConnected", {
+        params ["", "", "", "", "_ownerId", "_clientIdStr"];
+
+        // CBA events do not support client Id
+        missionNamespace setVariable [QGVAR(clientId), _clientIdStr, _ownerId];
+    }];
+};
+
+if (hasInterface) then {
+    GVAR(clientId) = "";
+};
+
 ADDON = true;

--- a/addons/common/functions/fnc_createPlayerMarker.sqf
+++ b/addons/common/functions/fnc_createPlayerMarker.sqf
@@ -30,7 +30,7 @@ if (_channel isEqualType "") then {
 };
 
 if (_channel < CHANNEL_MIN || {_channel > CHANNEL_MAX}) exitWith {
-    ERROR_1("Invalid channel given!",_channel);
+    ERROR_1("Invalid channel given! - %1",_channel);
 
     "" // return
 };

--- a/addons/common/functions/fnc_createPlayerMarker.sqf
+++ b/addons/common/functions/fnc_createPlayerMarker.sqf
@@ -1,0 +1,44 @@
+#include "script_component.hpp"
+/*
+ * Author: <author>
+ * Create local player owned marker.
+ *
+ * Arguments:
+ * 0: Marker position <ARRAY, OBJECT>
+ * 1: Channel to create marker on <STRING, NUMBER>
+ *
+ * Return Value:
+ * Marker ID, empty string if could not create <STRING>
+ *
+ * Example:
+ * [player ,"global"] call afm_common_fnc_createPlayerMarker
+ *
+ * Public: No
+ */
+
+#define CHANNEL_NAMES   ["global", "side", "command", "group", "vehicle", "direct"]
+#define CHANNEL_MIN     0
+#define CHANNEL_MAX     5
+
+params [
+    ["_position", [0,0,0], [[], objNull]],
+    ["_channel", 1, [0, ""]]
+];
+
+if (_channel isEqualType "") then {
+    _channel = CHANNEL_NAMES find _channel;
+};
+
+if (_channel < CHANNEL_MIN || {_channel > CHANNEL_MAX}) exitWith {
+    ERROR_1("Invalid channel given!",_channel);
+
+    "" // return
+};
+
+// create marker id
+private _id = format ["%1_%2", QUOTE(PREFIX), GVAR(playerMarkerIdx)];
+GVAR(playerMarkerIdx) = GVAR(playerMarkerIdx) + 1;
+
+private _markerId = format ["_USER_DEFINED #%1/%2/%3", GVAR(clientId), _id, _channel];
+
+createMarker [_markerId, _position] // return


### PR DESCRIPTION
**When merged this pull request will:**
- title

This PR allows to create markers with such IDs that they are seen by game as owned by the player. Markers created by it will be faded out when viewing different channel than the one it was created on, also it will correctly show owner on hover over marker. 

However due to usage `createMarker` command the marker will be visible to everyone, not only the player side, group etc. 

To handle this properly it would need to use `createMarkerLocal` with correct remote execution, jip handling etc. current implementation is enough for PvE usage thus I think it can be merged and improved in future if more robust/advanced functionality is needed.