### PR TITLE
Add Zeus button to debug console

### DIFF
--- a/addons/curator/XEH_postInit.sqf
+++ b/addons/curator/XEH_postInit.sqf
@@ -8,6 +8,7 @@ if (isServer) then {
         INFO_1("Assigning Zeus to '%1'", _unit);
 
         private _curatorModule = [_unit] call FUNC(getFreeCuratorModule);
+        unassignCurator getAssignedCuratorLogic _unit;
         _unit assignCurator _curatorModule;
     }] call CBA_fnc_addEventHandler;
 

--- a/addons/curator/XEH_postInit.sqf
+++ b/addons/curator/XEH_postInit.sqf
@@ -25,4 +25,5 @@ if (isServer) then {
 
 if (hasInterface) then {
     [QGVAR(objectAdd), player] call CBA_fnc_serverEvent;
+    [[LLSTRING(GetZeus), LLSTRING(GetZeus_Description)], {player call FUNC(assignZeus)}] call EFUNC(debug_console,addButton);
 };

--- a/addons/curator/config.cpp
+++ b/addons/curator/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
-            "afm_main"
+            "afm_main",
+            "afm_debug_console"
         };
         author = "ArmaForces";
         VERSION_CONFIG;

--- a/addons/curator/stringtable.xml
+++ b/addons/curator/stringtable.xml
@@ -8,5 +8,13 @@
             <English>Controls whether unit will have Zeus interface.</English>
             <Polish>Ustala czy jednostka ma mieć dostęp do interfejsu Zeusa.</Polish>
         </Key>
+        <Key ID="STR_AFM_Curator_GetZeus">
+            <English>Zeus</English>
+            <Polish>Zeus</Polish>
+        </Key>
+        <Key ID="STR_AFM_Curator_GetZeus_Description">
+            <English>Give yourself Zeus functinality.</English>
+            <Polish>Daj sobie funkcjonalność Zeusa.</Polish>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds button to debug console which allows to assign yourself an Zeus Module
- Unassign current Zeus when assigning new one, allows to reasign yourself a new module in case something broke (happens rarely that functionality is lost despite having module assigned)