### PR TITLE
Create flagpoles objects for vanilla country flag markers

### DIFF
--- a/addons/flags/$PBOPREFIX$
+++ b/addons/flags/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\afm\addons\flags

--- a/addons/flags/CfgEventHandlers.hpp
+++ b/addons/flags/CfgEventHandlers.hpp
@@ -1,0 +1,15 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/flags/CfgVehicles.hpp
+++ b/addons/flags/CfgVehicles.hpp
@@ -1,0 +1,4 @@
+class CfgVehicles {
+    class Flag_White_F;
+    #include "FlagsVanilla.hpp"
+};

--- a/addons/flags/FlagsVanilla.hpp
+++ b/addons/flags/FlagsVanilla.hpp
@@ -1,0 +1,38 @@
+#define FLAG(COUNTRY) class GVAR(COUNTRY): Flag_White_F { \
+    author = "ArmaForces, A3"; \
+    displayName = QUOTE(Flag (##COUNTRY##)); \
+\
+    class EventHandlers { \
+        init = QUOTE((_this select 0) setFlagTexture QUOTE(QUOTE(\A3\ui_f\data\map\markers\flags\##COUNTRY##_ca.paa))); \
+    }; \
+}
+
+FLAG(Belgium);
+FLAG(Canada);
+FLAG(Croatia);
+FLAG(CzechRepublic);
+FLAG(Denmark);
+FLAG(France);
+FLAG(Georgia);
+FLAG(Germany);
+FLAG(Greece);
+FLAG(Hungary);
+FLAG(Iceland);
+FLAG(Italy);
+FLAG(Luxembourg);
+FLAG(Netherlands);
+FLAG(Norway);
+FLAG(Poland);
+FLAG(Portugal);
+FLAG(Slovakia);
+FLAG(Slovenia);
+FLAG(Spain);
+
+class GVAR(Russia): Flag_White_F {
+    author = "ArmaForces, A3";
+    displayName = "Flag (Russia)";
+
+    class EventHandlers {
+        init = '(_this select 0) setFlagTexture "\A3\UI_F_Enoch\Data\CfgMarkers\Russia_CA.paa"';
+    };
+};

--- a/addons/flags/XEH_postInit.sqf
+++ b/addons/flags/XEH_postInit.sqf
@@ -1,0 +1,1 @@
+#include "script_component.hpp"

--- a/addons/flags/XEH_preInit.sqf
+++ b/addons/flags/XEH_preInit.sqf
@@ -1,0 +1,4 @@
+#include "script_component.hpp"
+ADDON = false;
+#include "XEH_PREP.hpp"
+ADDON = true;

--- a/addons/flags/XEH_preStart.sqf
+++ b/addons/flags/XEH_preStart.sqf
@@ -1,0 +1,2 @@
+#include "script_component.hpp"
+#include "XEH_PREP.hpp"

--- a/addons/flags/config.cpp
+++ b/addons/flags/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "afm_common"
+        };
+        author = "ArmaForces";
+        VERSION_CONFIG;
+    };
+};
+
+
+#include "CfgEventHandlers.hpp"

--- a/addons/flags/config.cpp
+++ b/addons/flags/config.cpp
@@ -16,3 +16,4 @@ class CfgPatches {
 
 
 #include "CfgEventHandlers.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/flags/functions/script_component.hpp
+++ b/addons/flags/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\z\afm\addons\flags\script_component.hpp"

--- a/addons/flags/script_component.hpp
+++ b/addons/flags/script_component.hpp
@@ -1,0 +1,14 @@
+#define COMPONENT flags
+#include "\z\afm\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+
+#ifdef DEBUG_ENABLED_FLAGS
+    #define DEBUG_MODE_FULL
+#endif
+    #ifdef DEBUG_SETTINGS_FLAGS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_FLAGS
+#endif
+
+#include "\z\afm\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- title

Flags created this way are a bit different than those created using dedicated flag texture, look img 2 for comparison between Spain flag created from marker and USA flag available in vanilla.

<details>
  <summary>Created flagpoles list</summary>

- Belgium
- Canada
- Croatia
- CzechRepublic
- Denmark
- France
- Georgia
- Germany
- Greece
- Hungary
- Iceland
- Italy
- Luxembourg
- Netherlands
- Norway
- Poland
- Portugal
- Russia
- Slovakia
- Slovenia
- Spain
</details>

<details>
  <summary>Images</summary>

![20200409141922_1](https://user-images.githubusercontent.com/30000580/78895926-ecbd2a00-7a6f-11ea-95c0-c7181412fc18.jpg)

![20200409141937_1](https://user-images.githubusercontent.com/30000580/78895929-edee5700-7a6f-11ea-92d0-e477f62bd1fd.jpg)
</details>
