### PR TITLE
Allow ACRE Babel and PerSideRadios setup from settings

### DIFF
--- a/addons/acre/$PBOPREFIX$
+++ b/addons/acre/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\afm\addons\acre

--- a/addons/acre/CfgEventHandlers.hpp
+++ b/addons/acre/CfgEventHandlers.hpp
@@ -1,0 +1,15 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/acre/README.md
+++ b/addons/acre/README.md
@@ -1,0 +1,7 @@
+## ACRE
+
+Standard ArmaForces ACRE framework for missions
+
+### Authors
+
+- [3Mydlo3](http://github.com/3Mydlo3)

--- a/addons/acre/XEH_PREP.hpp
+++ b/addons/acre/XEH_PREP.hpp
@@ -1,0 +1,1 @@
+PREP(init);

--- a/addons/acre/XEH_postInit.sqf
+++ b/addons/acre/XEH_postInit.sqf
@@ -1,0 +1,1 @@
+#include "script_component.hpp"

--- a/addons/acre/XEH_postInit.sqf
+++ b/addons/acre/XEH_postInit.sqf
@@ -1,1 +1,3 @@
 #include "script_component.hpp"
+
+call FUNC(init);

--- a/addons/acre/XEH_postInit.sqf
+++ b/addons/acre/XEH_postInit.sqf
@@ -1,5 +1,5 @@
 #include "script_component.hpp"
 
-if (EGVAR(common,acre)) then {
+if (EGVAR(common,acre) && {GVAR(enabled)}) then {
     call FUNC(init);
 };

--- a/addons/acre/XEH_postInit.sqf
+++ b/addons/acre/XEH_postInit.sqf
@@ -1,3 +1,5 @@
 #include "script_component.hpp"
 
-call FUNC(init);
+if (EGVAR(common,acre)) then {
+    call FUNC(init);
+};

--- a/addons/acre/XEH_preInit.sqf
+++ b/addons/acre/XEH_preInit.sqf
@@ -1,0 +1,4 @@
+#include "script_component.hpp"
+ADDON = false;
+#include "XEH_PREP.hpp"
+ADDON = true;

--- a/addons/acre/XEH_preInit.sqf
+++ b/addons/acre/XEH_preInit.sqf
@@ -1,4 +1,7 @@
 #include "script_component.hpp"
 ADDON = false;
 #include "XEH_PREP.hpp"
+
+#include "initSettings.sqf"
+
 ADDON = true;

--- a/addons/acre/XEH_preInit.sqf
+++ b/addons/acre/XEH_preInit.sqf
@@ -1,5 +1,8 @@
 #include "script_component.hpp"
 ADDON = false;
+
+if (!EGVAR(common,acre)) exitWith {};
+
 #include "XEH_PREP.hpp"
 
 #include "initSettings.sqf"

--- a/addons/acre/XEH_preStart.sqf
+++ b/addons/acre/XEH_preStart.sqf
@@ -1,0 +1,2 @@
+#include "script_component.hpp"
+#include "XEH_PREP.hpp"

--- a/addons/acre/config.cpp
+++ b/addons/acre/config.cpp
@@ -10,6 +10,7 @@ class CfgPatches {
             "afm_common"
         };
         author = "ArmaForces";
+        authors[] = {"3Mydlo3"};
         VERSION_CONFIG;
     };
 };

--- a/addons/acre/config.cpp
+++ b/addons/acre/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "afm_common"
+        };
+        author = "ArmaForces";
+        VERSION_CONFIG;
+    };
+};
+
+
+#include "CfgEventHandlers.hpp"

--- a/addons/acre/functions/fnc_init.sqf
+++ b/addons/acre/functions/fnc_init.sqf
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+/*
+ * Author: veteran29
+ * Initialize ACRE functionalities.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * call afm_acre_fnc_init
+ *
+ * Public: No
+ */
+
+if (hasInterface) then {
+    [GVAR(babel), GVAR(perSideRadios)] call acre_api_fnc_setupMission;
+};
+
+nil

--- a/addons/acre/functions/script_component.hpp
+++ b/addons/acre/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\z\afm\addons\acre\script_component.hpp"

--- a/addons/acre/initSettings.sqf
+++ b/addons/acre/initSettings.sqf
@@ -1,4 +1,15 @@
 [
+    QGVAR(enabled),
+    "CHECKBOX",
+    [ELSTRING(common,Enabled), ELSTRING(common,Enabled_Description)],
+    LSTRING(DisplayName),
+    false,
+    1,
+    {},
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(babel),
     "CHECKBOX",
     [LSTRING(Babel), LSTRING(Babel_Description)],

--- a/addons/acre/initSettings.sqf
+++ b/addons/acre/initSettings.sqf
@@ -1,0 +1,21 @@
+[
+    QGVAR(babel),
+    "CHECKBOX",
+    [LSTRING(Babel), LSTRING(Babel_Description)],
+    LSTRING(DisplayName),
+    false,
+    1,
+    {},
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(perSideRadios),
+    "CHECKBOX",
+    [LSTRING(PerSideRadios), LSTRING(PerSideRadios_Description)],
+    LSTRING(DisplayName),
+    false,
+    1,
+    {},
+    true
+] call CBA_fnc_addSetting;

--- a/addons/acre/script_component.hpp
+++ b/addons/acre/script_component.hpp
@@ -1,0 +1,14 @@
+#define COMPONENT acre
+#include "\z\afm\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+
+#ifdef DEBUG_ENABLED_ACRE
+    #define DEBUG_MODE_FULL
+#endif
+    #ifdef DEBUG_SETTINGS_ACRE
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_ACRE
+#endif
+
+#include "\z\afm\addons\main\script_macros.hpp"

--- a/addons/acre/stringtable.xml
+++ b/addons/acre/stringtable.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="AFM">
+    <Package name="Acre">
+        <Key ID="STR_AFM_Acre_DisplayName">
+            <English>ArmaForces - ACRE</English>
+            <Polish>ArmaForces - ACRE</Polish>
+        </Key>
+        <Key ID="STR_AFM_Acre_Babel">
+            <English>Babel</English>
+            <Polish>Babel</Polish>
+        </Key>
+        <Key ID="STR_AFM_Acre_Babel_Description">
+            <English>Each side will have it's own babel language assigned and won't understand each other. Requires mission restart to change.</English>
+            <Polish>Każda strona będzie miała swój język babel i nie będą się rozumieć. Zmiana wymaga restartu misji.</Polish>
+        </Key>
+        <Key ID="STR_AFM_Acre_PerSideRadios">
+            <English>Per Side Radios</English>
+            <Polish>Kanały per strona</Polish>
+        </Key>
+        <Key ID="STR_AFM_Acre_PerSideRadios_Description">
+            <English>Each side will have it's own frequency on radio and won't hear each other. Requires mission restart to change.</English>
+            <Polish>Każda strona będzie miała swoje częstotliwości i nie będą się słyszeć na radiu. Zmiana wymaga restartu misji.</Polish>
+        </Key>
+    </Package>
+</Project>

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -8,6 +8,7 @@ GVAR(aceFatigue) = IS_MOD_LOADED(ace_advanced_fatigue);
 GVAR(aceMedical) = IS_MOD_LOADED(ace_medical_engine);
 GVAR(aceTagging) = IS_MOD_LOADED(ace_tagging);
 GVAR(aceFinger) = IS_MOD_LOADED(ace_finger);
+GVAR(acre) = IS_MOD_LOADED(acre_main);
 
 if (isServer) then {
     GVAR(clientId) = "2";

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="AFM">
+    <Package name="Common">
+        <Key ID="STR_AFM_Common_DisplayName">
+            <English>ArmaForces - Common</English>
+            <Polish>ArmaForces - Common</Polish>
+        </Key>
+        <Key ID="STR_AFM_Common_Enabled">
+            <English>Enable component</English>
+            <Polish>Włącz komponent</Polish>
+        </Key>
+        <Key ID="STR_AFM_Common_Enabled_Description">
+            <English>Controls whether this component is active.</English>
+            <Polish>Pozwala kontrolować czy komponent jest włączony.</Polish>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Create ACRE component
- Add `EGVAR(common,acre)` for checking if `acre_main` is loaded
- Add `ELSTRING(common,Enabled)` and `ELSTRING(common,Enabled_Description)` for generic "Enable component" string.
- title

This way we don't need ACRE module in PvP missions.