### PR TITLE
Save player's group when disconnected

### DIFF
--- a/addons/back_to_game/functions/fnc_dialogConfirm.sqf
+++ b/addons/back_to_game/functions/fnc_dialogConfirm.sqf
@@ -21,6 +21,7 @@ player allowDamage false;
 [{player allowDamage true}, [], 5] call CBA_fnc_waitAndExecute;
 player playAction "PlayerProne";
 player setUnitLoadout (GVAR(savegameData) select 0);
+[player] join (GVAR(savegameData) select 1); // Join player back to group
 
 [QGVAR(teleportPlayer), GVAR(savegameData)] call CBA_fnc_localEvent;
 

--- a/addons/back_to_game/functions/fnc_dialogConfirm.sqf
+++ b/addons/back_to_game/functions/fnc_dialogConfirm.sqf
@@ -21,7 +21,12 @@ player allowDamage false;
 [{player allowDamage true}, [], 5] call CBA_fnc_waitAndExecute;
 player playAction "PlayerProne";
 player setUnitLoadout (GVAR(savegameData) select 0);
-[player] join (GVAR(savegameData) select 1); // Join player back to group
+private _oldGroup = GVAR(savegameData) select 1;
+
+if (!(group player isEqualTo _oldGroup) && {!isNull _oldGroup}) then {
+    // Join player back to group
+    [player] join _oldGroup;
+};
 
 [QGVAR(teleportPlayer), GVAR(savegameData)] call CBA_fnc_localEvent;
 

--- a/addons/back_to_game/functions/fnc_savePlayerData.sqf
+++ b/addons/back_to_game/functions/fnc_savePlayerData.sqf
@@ -21,7 +21,7 @@ params ["_unit", "_uid"];
 // Save player's loadout, vehicle and position
 private _loadout = getUnitLoadout _unit;
 private _pos = getPosATL _unit;
-GVAR(disconnectedPlayers) setVariable [_uid, [_loadout, vehicle _unit, _pos]];
+GVAR(disconnectedPlayers) setVariable [_uid, [_loadout, group _unit, vehicle _unit, _pos]];
 
 INFO_2("%1 UID: %2 disconnected, saved data.",name _unit,_uid);
 

--- a/addons/back_to_game/functions/fnc_teleportPlayer.sqf
+++ b/addons/back_to_game/functions/fnc_teleportPlayer.sqf
@@ -17,7 +17,7 @@
  * Public: No
  */
 
-params ["", "_vehicle", "_pos"];
+params ["", "", "_vehicle", "_pos"];
 
 private _leader = leader group player;
 


### PR DESCRIPTION
**When merged this pull request will:**
- title

Previously when player changed group, he could not be teleported back to his leader. After rejoining he was in his original group. Now this behaviour is fixed and when player confirms teleportation, he joins his old group if possible.