### PR TITLE
Fix password control spacing on MP missions screen

### DIFF
--- a/addons/main_menu/XEH_multiplayerDisplay.sqf
+++ b/addons/main_menu/XEH_multiplayerDisplay.sqf
@@ -28,11 +28,12 @@ private _passwordInput  = _display ctrlCreate ["RscEdit", -1];
 private _passwordButton = _display ctrlCreate ["RscButtonMenu", -1];
 private _missionsButton = _display ctrlCreate ["RscButtonMenu", -1];
 
+#define BUTTON_SPACING (0.1 * GUI_GRID_W)
 #define BUTTON_W _offsetW
-#define MP_PWD_INPUT_X (_baseX + BUTTON_W * 2 + (0.25 * GUI_GRID_W))
+#define MP_PWD_INPUT_X (_baseX + BUTTON_W * 2 + (2 * BUTTON_SPACING))
 
 _missionsButton ctrlSetPosition [
-    _baseX + BUTTON_W + (0.1 * GUI_GRID_W),
+    _baseX + BUTTON_W + BUTTON_SPACING,
     _baseY,
     BUTTON_W,
     _offsetH
@@ -44,7 +45,7 @@ _missionsButton ctrlCommit 0;
 _passwordInput ctrlSetPosition [
     MP_PWD_INPUT_X,
     _baseY,
-    _rightBorder - MP_PWD_INPUT_X - BUTTON_W,
+    _rightBorder - MP_PWD_INPUT_X - BUTTON_W - BUTTON_SPACING,
     _offsetH //+ pixelH
 ];
 _passwordButton ctrlSetPosition [


### PR DESCRIPTION
**When merged this pull request will:**
- title

<details>
  <summary>
Before
</summary>

![obraz](https://user-images.githubusercontent.com/30000580/92371288-b574a700-f0fb-11ea-80c1-57a9e00a5716.png)
</details>

<details>
  <summary>
After
</summary>

![obraz](https://user-images.githubusercontent.com/30000580/92371347-c6bdb380-f0fb-11ea-8f49-b4e9329157c1.png)

</details>