### PR TITLE
Prevent saving player data if he was dead when disconnected

### DIFF
--- a/addons/back_to_game/functions/fnc_handleDisconnected.sqf
+++ b/addons/back_to_game/functions/fnc_handleDisconnected.sqf
@@ -25,9 +25,14 @@ if (!isServer && {hasInterface}) exitWith {
     nil
 };
 
+if (!alive _unit) exitWith {
+    INFO_1("Player %1 was dead when disconnected. No data was saved.",name _unit);
+    nil
+};
+
 [_unit, _uid] call FUNC(savePlayerData);
 
-if (GVAR(removeBody) && {alive _unit}) then {
+if (GVAR(removeBody)) then {
     INFO_1("Removing body of %1",name _unit);
     deleteVehicle _unit;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix potential bug (or more like unwanted behaviour) of saving player data even if he is dead, thus giving him ability to come back where he died after reconnection.