### PR TITLE
Add setting to disable remote sensors on clients

### DIFF
--- a/addons/remotesensors/$PBOPREFIX$
+++ b/addons/remotesensors/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\afm\addons\remotesensors

--- a/addons/remotesensors/CfgEventHandlers.hpp
+++ b/addons/remotesensors/CfgEventHandlers.hpp
@@ -1,0 +1,5 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/addons/remotesensors/XEH_preInit.sqf
+++ b/addons/remotesensors/XEH_preInit.sqf
@@ -1,0 +1,6 @@
+#include "script_component.hpp"
+ADDON = false;
+
+#include "initSettings.sqf"
+
+ADDON = true;

--- a/addons/remotesensors/config.cpp
+++ b/addons/remotesensors/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "afm_common"
+        };
+        author = "ArmaForces";
+        authors[] = {"veteran29"};
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/remotesensors/initSettings.sqf
+++ b/addons/remotesensors/initSettings.sqf
@@ -1,0 +1,17 @@
+
+[
+    QGVAR(enabled),
+    "CHECKBOX",
+    [LSTRING(Enabled), LSTRING(Enabled_Description)],
+    LSTRING(DisplayName),
+    true,
+    true,
+    {
+        if (isServer || {!hasInterface}) exitWith {
+            INFO("Server or HC, skipping");
+        };
+
+        INFO_1("disableRemoteSensors - %1",!GVAR(enabled));
+        disableRemoteSensors !GVAR(enabled);
+    }
+] call CBA_fnc_addSetting;

--- a/addons/remotesensors/script_component.hpp
+++ b/addons/remotesensors/script_component.hpp
@@ -1,0 +1,14 @@
+#define COMPONENT remotesensors
+#include "\z\afm\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+
+#ifdef DEBUG_ENABLED_REMOTESENSORS
+    #define DEBUG_MODE_FULL
+#endif
+    #ifdef DEBUG_SETTINGS_REMOTESENSORS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_REMOTESENSORS
+#endif
+
+#include "\z\afm\addons\main\script_macros.hpp"

--- a/addons/remotesensors/stringtable.xml
+++ b/addons/remotesensors/stringtable.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="AFM">
+    <Package name="RemoteSensors">
+        <Key ID="STR_AFM_RemoteSensors_DisplayName">
+            <English>ArmaForces - Remote Sensors</English>
+        </Key>
+        <Key ID="STR_AFM_RemoteSensors_Enabled">
+            <English>Enable remote sensors on clients</English>
+        </Key>
+        <Key ID="STR_AFM_RemoteSensors_Enabled_Description">
+            <English>This command will halt raycasting calculations (on the local machine only) for all groups which don't contain any local entities. Units, that are not in a group with at least one local member, will not check visibility of other units. This will cause, that remote units will not have updated knowsAbout and it will save some CPU time. If a group contains a single local entity then calculations will still be performed for the entire group.</English>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
**When merged this pull request will:**
- title
- https://community.bistudio.com/wiki/disableRemoteSensors

According to talk I had with our friends at Ark and @FPArma (@cyruz143 and @diwako) disabling this does not have any negative effects on gameplay. Only the 3 commands mentioned on wiki will be broken on clients but these are almost never used in standard gameplay scenarios.

Disabling this should net minimal fps gains when playing with standard non agent based AI.