### PR TITLE
Prevent spectator restart if mission not started yet

### DIFF
--- a/addons/spectator/functions/fnc_restart.sqf
+++ b/addons/spectator/functions/fnc_restart.sqf
@@ -15,7 +15,7 @@
  * Public: No
  */
 
-if (!isServer) exitWith {};
+if (!isServer || {time < 1}) exitWith {};
 
 WARNING("Restarting spectator!");
 [QGVAR(reloadLocal)] call CBA_fnc_globalEvent;


### PR DESCRIPTION
**When merged this pull request will:**
- title
- prevents RPT spam at mission start