### PR TITLE
Port grenade bind warning from legacy AF Mods

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -15,6 +15,7 @@ GVAR(aceInteractMenu) = IS_MOD_LOADED(ace_interact_menu);
 GVAR(aceMedical) = IS_MOD_LOADED(ace_medical_engine);
 GVAR(aceSafemode) = IS_MOD_LOADED(ace_safemode);
 GVAR(aceTagging) = IS_MOD_LOADED(ace_tagging);
+GVAR(aceThrowing) = IS_MOD_LOADED(ace_advanced_throwing);
 GVAR(acre) = IS_MOD_LOADED(acre_main);
 
 if (isServer) then {

--- a/addons/safestart/README.md
+++ b/addons/safestart/README.md
@@ -2,6 +2,8 @@
 
 Module for safe game start, lowers player weapon and optionally sets safety on them if ACE is loaded to prevent misfire.
 
+Additionally warns player if he has grenade bound to `G` and informs him of ACE Throwing and the responsibility if he chooses not to rebind the `G` key.
+
 ### Authors
 
 - [veteran29](https://github.com/veteran29)

--- a/addons/safestart/XEH_PREP.hpp
+++ b/addons/safestart/XEH_PREP.hpp
@@ -1,1 +1,4 @@
+PREP(grenadeBindCondition);
+PREP(grenadeBindWarn);
 PREP(lowerWeapon);
+PREP(openKeybinding);

--- a/addons/safestart/XEH_postInitClient.sqf
+++ b/addons/safestart/XEH_postInitClient.sqf
@@ -3,3 +3,5 @@
 if (is3DEN) exitWith {};
 
 [QGVAR(enableSafety), player] call CBA_fnc_localEvent;
+
+call FUNC(grenadeBindWarn);

--- a/addons/safestart/config.cpp
+++ b/addons/safestart/config.cpp
@@ -1,4 +1,5 @@
 #include "script_component.hpp"
+
 class CfgPatches {
     class ADDON {
         name = COMPONENT_NAME;
@@ -12,6 +13,5 @@ class CfgPatches {
         VERSION_CONFIG;
     };
 };
-
 
 #include "CfgEventHandlers.hpp"

--- a/addons/safestart/functions/fnc_grenadeBindCondition.sqf
+++ b/addons/safestart/functions/fnc_grenadeBindCondition.sqf
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+/*
+ * Author: veteran29
+ * Checks if player has G bound to Throw and if he was not warned yet.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * True if warning should be shown <BOOL>
+ *
+ * Public: No
+ */
+
+#define DIK_G 34
+
+DIK_G in actionKeys "Throw" && {!(profileNamespace getVariable [QGVAR(grenadeConfirmed), false])}

--- a/addons/safestart/functions/fnc_grenadeBindWarn.sqf
+++ b/addons/safestart/functions/fnc_grenadeBindWarn.sqf
@@ -13,46 +13,60 @@
  * Public: No
  */
 
+#define CONFIRMED 1
+#define DISCARDED 2
+#define THROW_KEYBIND "STR_USRACT_THROW"
+
 if (!(call FUNC(grenadeBindCondition))) exitWith { nil };
 
-[{!isNull MISSION_DISPLAY}, {
-    private _script = [] spawn {
-
-        private _warnMessage = if (EGVAR(common,aceThrowing)) then {
-            LLSTRING(ThrowBind_Warn)
-        } else {
-            LLSTRING(ThrowBind_WarnNoACEThrowing)
-        };
-
-        private _confirm = [
-            parseText _warnMessage,
-            "Dangerous bind!",
-            "Rebind",
-            LLSTRING(ThrowBind_Deny)
-        ] call BIS_fnc_guiMessage;
-
-        // Open rebiding screen
-        if (_confirm) exitWith {
-            ["STR_USRACT_THROW"] call FUNC(openKeybinding);
-        };
-
-        // Ask for second confirmation
-        private _confirm = [
-            parseText LLSTRING(ThrowBind_Warn2),
-            "Dangerous bind!",
-            "Rebind",
-            LLSTRING(ThrowBind_Confirm)
-        ] call BIS_fnc_guiMessage;
-
-        // Open rebiding screen
-        if (_confirm) exitWith {
-            ["STR_USRACT_THROW"] call FUNC(openKeybinding);
-        };
-
-        // Do not ask again
-        profileNamespace setVariable [QGVAR(grenadeConfirmed), true];
-        saveProfileNamespace;
+private _fnc_secondWarning = {
+    params ["", "_confirm"];
+    if (_confirm isEqualTo CONFIRMED) exitWith {
+        // Open rebinding screen
+        [{
+            [THROW_KEYBIND] call FUNC(openKeybinding);
+        }] call CBA_fnc_execNextFrame;
     };
-}] call CBA_fnc_waitUntilAndExecute;
+
+    // Ask again
+    [{
+        [
+            LLSTRING(ThrowBind_Title),
+            LLSTRING(ThrowBind_Warn2),
+            false,
+            {},
+            {
+                params ["", "_confirm"];
+                if (_confirm isEqualTo CONFIRMED) exitWith {
+                    // Open rebinding screen
+                    [{
+                        [THROW_KEYBIND] call FUNC(openKeybinding);
+                    }] call CBA_fnc_execNextFrame;
+                };
+
+                // Do not ask again
+                profileNamespace setVariable [QGVAR(grenadeConfirmed), true];
+                saveProfileNamespace;
+            }
+        ] call EFUNC(common,modal);
+    }] call CBA_fnc_execNextFrame;
+};
+
+[{!isNull MISSION_DISPLAY}, {
+    params ["_fnc_onClose"];
+    private _warnMessage = if (EGVAR(common,aceThrowing)) then {
+        LLSTRING(ThrowBind_Warn)
+    } else {
+        LLSTRING(ThrowBind_WarnNoACEThrowing)
+    };
+
+    [
+        LLSTRING(ThrowBind_Title),
+        _warnMessage,
+        false,
+        {},
+        _this
+    ] call EFUNC(common,modal);
+}, _fnc_secondWarning] call CBA_fnc_waitUntilAndExecute;
 
 nil

--- a/addons/safestart/functions/fnc_grenadeBindWarn.sqf
+++ b/addons/safestart/functions/fnc_grenadeBindWarn.sqf
@@ -1,0 +1,58 @@
+#include "script_component.hpp"
+/*
+ * Author: veteran29
+ * Warns the player that he has default bind "G" to throw grenade.
+ * It's considered good pratice to rebind it ;-)
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Public: No
+ */
+
+if (!(call FUNC(grenadeBindCondition))) exitWith { nil };
+
+[{!isNull MISSION_DISPLAY}, {
+    private _script = [] spawn {
+
+        private _warnMessage = if (EGVAR(common,aceThrowing)) then {
+            LLSTRING(ThrowBind_Warn)
+        } else {
+            LLSTRING(ThrowBind_WarnNoACEThrowing)
+        };
+
+        private _confirm = [
+            parseText _warnMessage,
+            "Dangerous bind!",
+            "Rebind",
+            LLSTRING(ThrowBind_Deny)
+        ] call BIS_fnc_guiMessage;
+
+        // Open rebiding screen
+        if (_confirm) exitWith {
+            ["STR_USRACT_THROW"] call FUNC(openKeybinding);
+        };
+
+        // Ask for second confirmation
+        private _confirm = [
+            parseText LLSTRING(ThrowBind_Warn2),
+            "Dangerous bind!",
+            "Rebind",
+            LLSTRING(ThrowBind_Confirm)
+        ] call BIS_fnc_guiMessage;
+
+        // Open rebiding screen
+        if (_confirm) exitWith {
+            ["STR_USRACT_THROW"] call FUNC(openKeybinding);
+        };
+
+        // Do not ask again
+        profileNamespace setVariable [QGVAR(grenadeConfirmed), true];
+        saveProfileNamespace;
+    };
+}] call CBA_fnc_waitUntilAndExecute;
+
+nil

--- a/addons/safestart/functions/fnc_lowerWeapon.sqf
+++ b/addons/safestart/functions/fnc_lowerWeapon.sqf
@@ -10,10 +10,11 @@
  * None
  *
  * Example:
- * [bob] call afm_main_fnc_lowerWeapon
+ * [player] call afm_safestart_fnc_lowerWeapon
  *
  * Public: Yes
  */
+
 params [
     ["_unit", objNull, [objNull]]
 ];

--- a/addons/safestart/functions/fnc_openKeybinding.sqf
+++ b/addons/safestart/functions/fnc_openKeybinding.sqf
@@ -1,0 +1,45 @@
+#include "script_component.hpp"
+/*
+ * Author: veteran29
+ * Opens keyboard action rebinding screen.
+ *
+ * Arguments:
+ * 0: Translation key for keybind <STRING> (Default: STR_USRACT_THROW)
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["STR_USRACT_THROW"] call afm_safestart_fnc_openKeybinding
+ *
+ * Public: No
+ */
+
+#define CONTROLS_DISPLAY        (findDisplay 4)
+#define CTRL_CONTROLS           303
+#define CTRL_KEYBIND_CATEGORY   108
+#define CTRL_KEYBIND_KEYS       102
+
+params [
+    ["_keybindingKey", "STR_USRACT_THROW", [""]]
+];
+
+private _interruptDisplay = MISSION_DISPLAY createDisplay (["RscDisplayInterrupt", "RscDisplayMPInterrupt"] select isMultiplayer);
+private _controlsCtrl = _interruptDisplay displayCtrl CTRL_CONTROLS;
+ctrlActivate _controlsCtrl;
+
+[{!isNull CONTROLS_DISPLAY}, {
+    private _categoryCombo = CONTROLS_DISPLAY displayCtrl CTRL_KEYBIND_CATEGORY;
+    _categoryCombo lbSetCurSel 1;
+
+    private _keysList = CONTROLS_DISPLAY displayCtrl CTRL_KEYBIND_KEYS;
+
+    private _localizedKey = localize _this;
+    for "_idx" from 0 to (lbSize _keysList - 1) do {
+        if (_keysList lbText _idx == _localizedKey) exitWith {
+            _keysList lbSetCurSel _idx;
+        };
+    };
+}, _keybindingKey] call CBA_fnc_waitUntilAndExecute;
+
+nil

--- a/addons/safestart/script_component.hpp
+++ b/addons/safestart/script_component.hpp
@@ -12,3 +12,5 @@
 #endif
 
 #include "\z\afm\addons\main\script_macros.hpp"
+
+#define MISSION_DISPLAY (findDisplay 46)

--- a/addons/safestart/stringtable.xml
+++ b/addons/safestart/stringtable.xml
@@ -13,5 +13,25 @@
             <English>Locks your weapon safety on game start</English>
             <Polish>Powoduje zabezpieczenie broni podczas startu rozgrywki</Polish>
         </Key>
+        <Key ID="STR_AFM_Safestart_ThrowBind_Warn">
+            <English>Hey!&lt;br /&gt;You have bound &#39;Throw&#39; (Grenade) key to G which is easy to press and is considered a &#39;Dangerous&#39; bind.&lt;br /&gt;It&#39;s recommended to unbind the key as you can use ACE Throwing (Shift+G) or bind it to 2xG.&lt;br /&gt;Do you want to rebind the action?</English>
+            <Polish>Hej!&lt;br /&gt;Masz ustawiony &#39;Rzut&#39; (Granatem) pod klawiszem G który jest dość łatwo wcisnąć. Zalecane jest odbindowanie dla bezpieczeństwa siebie samego oraz otoczenia, zamiast tego można używać ACE Throwing (Shift+G) albo zbindować rzut na 2xG.&lt;br /&gt;Czy chcesz przebindować akcje?</Polish>
+        </Key>
+        <Key ID="STR_AFM_Safestart_ThrowBind_WarnNoACEThrowing">
+            <English>Hey!&lt;br /&gt;You have bound &#39;Throw&#39; (Grenade) key to G which is easy to press and is considered a &#39;Dangerous&#39; bind.&lt;br /&gt;It&#39;s recommended to bind it to 2xG.&lt;br /&gt;Do you want to rebind the action?</English>
+            <Polish>Hej!&lt;br /&gt;Masz ustawiony &#39;Rzut&#39; (Granatem) pod klawiszem G który jest dość łatwo wcisnąć. Zalecane jest przebindowanie na 2xG dla bezpieczeństwa siebie samego oraz otoczenia.&lt;br /&gt;Czy chcesz przebindować akcje?</Polish>
+        </Key>
+        <Key ID="STR_AFM_Safestart_ThrowBind_Warn2">
+            <English>Are you completly sure!? By confirming this you take full responsblity for all possible accidents.</English>
+            <Polish>Jesteś pewny!? Potwierdzając to bierzesz pełną odpowiedzialność za możliwe wypadki.</Polish>
+        </Key>
+        <Key ID="STR_AFM_Safestart_ThrowBind_Confirm">
+            <English>I'm sure</English>
+            <Polish>Jestem pewien</Polish>
+        </Key>
+        <Key ID="STR_AFM_Safestart_ThrowBind_Deny">
+            <English>No</English>
+            <Polish>Nie</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/safestart/stringtable.xml
+++ b/addons/safestart/stringtable.xml
@@ -13,6 +13,10 @@
             <English>Locks your weapon safety on game start</English>
             <Polish>Powoduje zabezpieczenie broni podczas startu rozgrywki</Polish>
         </Key>
+        <Key ID="STR_AFM_Safestart_ThrowBind_Title">
+            <English>Dangerous bind detected!</English>
+            <Polish>Wykryto niebezpieczne przypisanie klawiszy!</Polish>
+        </Key>
         <Key ID="STR_AFM_Safestart_ThrowBind_Warn">
             <English>Hey!&lt;br /&gt;You have bound &#39;Throw&#39; (Grenade) key to G which is easy to press and is considered a &#39;Dangerous&#39; bind.&lt;br /&gt;It&#39;s recommended to unbind the key as you can use ACE Throwing (Shift+G) or bind it to 2xG.&lt;br /&gt;Do you want to rebind the action?</English>
             <Polish>Hej!&lt;br /&gt;Masz ustawiony &#39;Rzut&#39; (Granatem) pod klawiszem G który jest dość łatwo wcisnąć. Zalecane jest odbindowanie dla bezpieczeństwa siebie samego oraz otoczenia, zamiast tego można używać ACE Throwing (Shift+G) albo zbindować rzut na 2xG.&lt;br /&gt;Czy chcesz przebindować akcje?</Polish>
@@ -24,14 +28,6 @@
         <Key ID="STR_AFM_Safestart_ThrowBind_Warn2">
             <English>Are you completly sure!? By confirming this you take full responsblity for all possible accidents.</English>
             <Polish>Jesteś pewny!? Potwierdzając to bierzesz pełną odpowiedzialność za możliwe wypadki.</Polish>
-        </Key>
-        <Key ID="STR_AFM_Safestart_ThrowBind_Confirm">
-            <English>I'm sure</English>
-            <Polish>Jestem pewien</Polish>
-        </Key>
-        <Key ID="STR_AFM_Safestart_ThrowBind_Deny">
-            <English>No</English>
-            <Polish>Nie</Polish>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add bind warning for player on mission start if he has grenade bound to `G`.

Ported from legacy AF Mods.
