### PR TITLE
Fix ACRE speaking volume not applied on game start

### DIFF
--- a/addons/acre/XEH_postInit.sqf
+++ b/addons/acre/XEH_postInit.sqf
@@ -6,6 +6,6 @@
             ERROR("Mission ACRE Modules detected! AFM ACRE module disabled.");
         };
         call FUNC(init);
-        call FUNC(adjustVoiceVolume);
+        [{acre_core_init}, FUNC(adjustVoiceVolume)] call CBA_fnc_waitUntilAndExecute;
     };
 }] call EFUNC(common,runAfterSettingsInit);


### PR DESCRIPTION
**When merged this pull request will:**
- title
- ACRE sets the speaking volume after it syncs with TS. This can take some time and happen after we've changed the volume.