### PR TITLE
Delay ACRE voice volume adjustment

### DIFF
--- a/addons/acre/XEH_postInit.sqf
+++ b/addons/acre/XEH_postInit.sqf
@@ -5,7 +5,11 @@
         if (call FUNC(acreModulesPresent)) exitWith {
             ERROR("Mission ACRE Modules detected! AFM ACRE module disabled.");
         };
+
         call FUNC(init);
-        [{acre_core_init}, FUNC(adjustVoiceVolume)] call CBA_fnc_waitUntilAndExecute;
+
+        [{acre_core_init}, {
+            [FUNC(adjustVoiceVolume), nil, 1] call CBA_fnc_waitAndExecute;
+        }] call CBA_fnc_waitUntilAndExecute;
     };
 }] call EFUNC(common,runAfterSettingsInit);


### PR DESCRIPTION
**When merged this pull request will:**
- previous PR made it adjust after ACRE connects to TS, however, the volume adjustment is made in RPC call which can take a few ms, delaying it for a second should fix this for most of the cases.