### PR TITLE
Spectator - Force remove death BIS_DeathBlur on spectator display load

### DIFF
--- a/addons/spectator/functions/fnc_onDisplayLoad.sqf
+++ b/addons/spectator/functions/fnc_onDisplayLoad.sqf
@@ -61,4 +61,10 @@ if (!isNull _counterDisplay) then {
 
 _display call FUNC(addPlayerStatePanel);
 
+// Removes death blur if present
+if (!isNil "BIS_DeathBlur") then {
+    BIS_DeathBlur ppEffectAdjust [0];
+    BIS_DeathBlur ppEffectCommit 0;
+};
+
 nil


### PR DESCRIPTION
**When merged this pull request will:**
- title
- In today ~~gównozeus~~mission a lot of people had persisting blur in spectator after they died. Executing the added code fixed the issue.

See: https://github.com/acemod/ACE3/blob/master/addons/spectator/functions/fnc_ui.sqf#L35-L39