### PR TITLE
Back to game - Add temporary debug

### DIFF
--- a/addons/back_to_game/functions/fnc_savePlayerData.sqf
+++ b/addons/back_to_game/functions/fnc_savePlayerData.sqf
@@ -25,6 +25,9 @@ private _handlerData = GVAR(saveHandlers) apply {[_x select 1, _unit call (_x se
 
 // filter ACRE2 radios
 if (EGVAR(common,acre)) then {
+    INFO_1("Loadout debug - %1",str _loadout);
+    INFO_1("%1",str (_loadout select 9));
+
     _loadout = [_loadout] call acre_api_fnc_filterUnitLoadout;
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- title

In some care occurrences, there's something weird going with the loadouts and this causes an error in the ACRE filter loadout function:
```
21:38:27 Error in expression <nitLoadout _loadout;
};

if ((_loadout select 9) select 2 == "ItemRadioAcreFlag>
21:38:27   Error position: <select 9) select 2 == "ItemRadioAcreFlag>
21:38:27   Error Zero divisor
21:38:27 File idi\acre\addons\api\fnc_filterUnitLoadout.sqf..., line 27
```