### PR TITLE
Loading - Use absolute size for loading screen logo

### DIFF
--- a/addons/loading/XEH_loadingDisplay.sqf
+++ b/addons/loading/XEH_loadingDisplay.sqf
@@ -17,9 +17,8 @@ params ["_display"];
 
 TRACE_1("Loading screen",_display);
 
-private _size = 0.1;
-private _width = _size * safezoneW;
-private _height = _size * safezoneH * (getResolution select 4);
+private _width = 256 * pixelW;
+private _height = 256 * pixelH;
 
 private _picture = _display ctrlCreate ["RscPicture", -1];
 _picture ctrlSetPosition [


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Use fixed 256x256 pixels

Prevents issues on triple head:
![image](https://github.com/ArmaForces/Mods/assets/4293906/c997aa8a-9869-4911-8f36-9cf9ee857cac)
