### PR TITLE
AI Disembark - Add locality check for allowCrewInImmobile

### DIFF
--- a/addons/ai_disembark/XEH_preInit.sqf
+++ b/addons/ai_disembark/XEH_preInit.sqf
@@ -13,7 +13,7 @@ PREP_RECOMPILE_END;
 
 ["LandVehicle", "InitPost", {
     params ["_vehicle"];
-    if (isAllowedCrewInImmobile _vehicle) exitWith {};
+    if (isAllowedCrewInImmobile _vehicle || !local _vehicle) exitWith {};
     private _allow = random 1 < GVAR(stayInImmobileChance);
     _vehicle allowCrewInImmobile [_allow, _allow];
 }] call CBA_fnc_addClassEventHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- The command has global effect and should be executed where vehicle is local